### PR TITLE
gallery pipeline improvements

### DIFF
--- a/.github/workflows/actions_s3_init_gallery.yml
+++ b/.github/workflows/actions_s3_init_gallery.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Check artifacts
         id: check_artifacts
         run: |
+          echo "checking artifacts..."
           if find bin/publisher/gallery -mindepth 1 -maxdepth 1 | read; then
             echo "has_packages=true" >> $GITHUB_OUTPUT
           fi
@@ -79,6 +80,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Check outputs
+        run: |
+          echo "${{ needs.build_packages.outputs.has_packages }}"
 
       - name: Download Gallery artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/actions_s3_init_gallery.yml
+++ b/.github/workflows/actions_s3_init_gallery.yml
@@ -5,13 +5,16 @@ on:
     # Enables manual triggering via GitHub Actions
 
 jobs:
-  build_and_publish_packages:
+  build_packages:
     runs-on: ubuntu-latest
     permissions:
       id-token: write # required by AWS aws-actions/configure-aws-credentials
       contents: read
     env:
       RCC_VERSION: v18.1.1
+
+    outputs:
+      has_packages: ${{ steps.check_artifacts.outputs.has_packages }}
 
     steps:
       - name: Checkout repository
@@ -26,43 +29,12 @@ jobs:
             echo "manifest.json does not exist. Proceeding with the workflow."
           fi
 
-      - name: Generate Gallery structure
+      - name: Build Gallery
         run: |
           cd bin
           curl -L -o rcc "https://cdn.sema4.ai/rcc/releases/${{ env.RCC_VERSION }}/linux64/rcc"
           chmod +x rcc
           ./rcc run -r publisher/robot.yaml -t "Build all packages"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: eu-west-1
-          role-to-assume: arn:aws:iam::710450854638:role/github-action-gallery
-          
-      - name: AWS S3 copies
-        run: |
-          echo "Initializing Gallery S3"
-          S3_BASE_URL="s3://downloads.robocorp.com/gallery/actions"
-          cd bin/publisher/gallery
-          ls -la
-
-          # Copy the Action Package subdirectories
-          # cache-control max-age=31536000, because these should be immutable
-          for dir in */; do
-            aws s3 cp "$dir" "$S3_BASE_URL/$dir" --recursive --cache-control max-age=31536000
-          
-            returnCode=$?
-
-            # If the upload of any package fails, we want to break the workflow, as to not upload the manifest,
-            # which should be the only source of truth. This is allow to re-run this workflow if some fails happened.
-            if [ $returnCode -ne 0 ]; then
-              echo "Upload of '$dir' package failed, exiting..."
-              exit 1
-            fi
-          done
-
-          # Copy the updated manifest
-          aws s3 cp manifest.json $S3_BASE_URL/manifest.json --cache-control max-age=120 --content-type "text/plain"
 
       - name: Save Gallery artifact
         uses: actions/upload-artifact@v4
@@ -70,8 +42,16 @@ jobs:
           name: gallery-artifact
           path: bin/publisher/gallery
 
+      - name: Check artifacts
+        id: check_artifacts
+        run: |
+          if find bin/publisher/gallery -mindepth 1 -maxdepth 1 | read; then
+            echo "has_packages=true" >> $GITHUB_OUTPUT
+          fi
+
   build_environments:
-    needs: build_and_publish_packages
+    needs: build_packages
+    if: ${{ needs.build_packages.outputs.has_packages == 'true' }}
     runs-on: ${{ matrix.os }}
     env:
       RCC_VERSION: v18.1.1
@@ -92,6 +72,10 @@ jobs:
           - name: macos
             os: macos-latest
             rcc_folder: macos64
+
+    outputs:
+      has_environments: ${{ steps.check_artifacts.outputs.has_environments }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -125,10 +109,20 @@ jobs:
           name: environments-artifact-${{ matrix.os }}
           path: bin/publisher/environments
 
+      - name: Check artifacts
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        id: check_artifacts
+        run: |
+          # Note that it's enough to only do it once (on single OS), running it on all 3 would result
+          # in redundant operations. 
+          if find bin/publisher/environments -mindepth 1 -maxdepth 1 | read; then
+            echo "has_environments=true" >> $GITHUB_OUTPUT
+          fi
 
-  publish_environments:
+
+  publish:
     runs-on: ubuntu-latest
-    needs: build_environments
+    needs: [build_packages, build_environments]
     permissions:
       id-token: write # required by AWS aws-actions/configure-aws-credentials
       contents: read
@@ -137,6 +131,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download Gallery artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: gallery-artifact
+          path: bin/publisher/gallery
+
+      - name: Download Environments artifact
         uses: actions/download-artifact@v4
         with:
           pattern: environments-artifact-*
@@ -149,7 +149,8 @@ jobs:
           aws-region: eu-west-1
           role-to-assume: arn:aws:iam::710450854638:role/github-action-gallery
 
-      - name: AWS S3 copies
+      - name: Publish environments
+        if: ${{ needs.build_environments.outputs.has_environments == 'true' }}
         run: |
           S3_BASE_URL="s3://downloads.robocorp.com/holotree/sema4ai"
           cd bin/publisher/environments
@@ -167,3 +168,29 @@ jobs:
               exit 1
             fi
           done
+
+      - name: Publish packages
+        if: ${{ needs.build_packages.outputs.has_packages == 'true' }}
+        run: |
+          echo "Initializing Gallery S3"
+          S3_BASE_URL="s3://downloads.robocorp.com/gallery/actions"
+          cd bin/publisher/gallery
+          ls -la
+
+          # Copy the Action Package subdirectories
+          # cache-control max-age=31536000, because these should be immutable
+          for dir in */; do
+            aws s3 cp "$dir" "$S3_BASE_URL/$dir" --recursive --cache-control max-age=31536000
+
+            returnCode=$?
+
+            # If the upload of any package fails, we want to break the workflow, as to not upload the manifest,
+            # which should be the only source of truth. This is allow to re-run this workflow if some fails happened.
+            if [ $returnCode -ne 0 ]; then
+              echo "Upload of '$dir' package failed, exiting..."
+              exit 1
+            fi
+          done
+
+          # Copy the updated manifest
+          aws s3 cp manifest.json $S3_BASE_URL/manifest.json --cache-control max-age=120 --content-type "text/plain"

--- a/.github/workflows/actions_s3_init_gallery.yml
+++ b/.github/workflows/actions_s3_init_gallery.yml
@@ -81,10 +81,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Check outputs
-        run: |
-          echo "${{ needs.build_packages.outputs.has_packages }}"
-
       - name: Download Gallery artifact
         uses: actions/download-artifact@v4
         with:
@@ -128,6 +124,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [build_packages, build_environments]
+    if: ${{ needs.build_packages.outputs.has_packages == 'true' || needs.build_environments.outputs.has_environments }}
     permissions:
       id-token: write # required by AWS aws-actions/configure-aws-credentials
       contents: read

--- a/.github/workflows/actions_s3_update_gallery.yml
+++ b/.github/workflows/actions_s3_update_gallery.yml
@@ -11,13 +11,16 @@ on:
       - 'actions/**'
 
 jobs:
-  build_and_publish_packages:
+  build_packages:
     runs-on: ubuntu-latest
     permissions:
       id-token: write # required by AWS aws-actions/configure-aws-credentials
       contents: read
     env:
       RCC_VERSION: v18.1.1
+
+    outputs:
+      has_packages: ${{ steps.check_artifacts.outputs.has_packages }}
 
     steps:
       - name: Checkout repository
@@ -39,50 +42,21 @@ jobs:
           chmod +x rcc
           ./rcc run -r publisher/robot.yaml -t "Build updated packages"
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: eu-west-1
-          role-to-assume: arn:aws:iam::710450854638:role/github-action-gallery
-          
-      - name: AWS S3 copies
-        run: |
-          echo "Updating Gallery S3"
-          S3_BASE_URL="s3://downloads.robocorp.com/gallery/actions"
-          cd bin/publisher/gallery
-          ls -la
-
-          # Copy the Action Package subdirectories. Note that since this is an update workflow,
-          # subdirectories will only contain packages which version's was actually bumped.
-          # cache-control max-age=31536000, because these should be immutable.
-          for dir in */; do
-            aws s3 cp "$dir" "$S3_BASE_URL/$dir" --recursive --cache-control max-age=31536000
-            
-              returnCode=$?
-
-              # If the upload of any package fails, we want to break the workflow, as to not update the manifest,
-              # which should be the only source of truth.
-              # Even if some packages will be uploaded before other one fails, manifest won't include them,
-              # and therefore they won't be available in clients to download, and will be eligible to re-upload
-              # on the next Gallery update run.
-              if [ $returnCode -ne 0 ]; then
-                echo "Upload of '$dir' package failed, exiting..."
-                exit 1
-              fi
-          
-          done
-
-          # Copy the updated manifest
-          aws s3 cp manifest.json $S3_BASE_URL/manifest.json --cache-control max-age=120 --content-type "text/plain"
-
       - name: Save Gallery artifact
         uses: actions/upload-artifact@v4
         with:
           name: gallery-artifact
           path: bin/publisher/gallery
 
+      - name: Check artifacts
+        id: check_artifacts
+        run: |
+          if find bin/publisher/gallery -mindepth 1 -maxdepth 1 | read; then
+            echo "has_packages=true" >> $GITHUB_OUTPUT
+          fi
+
   build_environments:
-    needs: build_and_publish_packages
+    needs: build_packages
     runs-on: ${{ matrix.os }}
     env:
       RCC_VERSION: v18.1.1
@@ -103,6 +77,10 @@ jobs:
           - name: macos
             os: macos-latest
             rcc_folder: macos64
+
+    outputs:
+      has_environments: ${{ steps.check_artifacts.outputs.has_environments }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -140,10 +118,20 @@ jobs:
           name: environments-artifact-${{ matrix.os }}
           path: bin/publisher/environments
 
+      - name: Check artifacts
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        id: check_artifacts
+        run: |
+          # Note that it's enough to only do it once (on single OS), running it on all 3 would result
+          # in redundant operations. 
+          if find bin/publisher/environments -mindepth 1 -maxdepth 1 | read; then
+            echo "has_environments=true" >> $GITHUB_OUTPUT
+          fi
 
-  publish_environments:
+
+  publish:
     runs-on: ubuntu-latest
-    needs: build_environments
+    needs: [build_packages, build_environments]
     permissions:
       id-token: write # required by AWS aws-actions/configure-aws-credentials
       contents: read
@@ -152,6 +140,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download Gallery artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: gallery-artifact
+          path: bin/publisher/gallery
+
+      - name: Download Environments artifact
         uses: actions/download-artifact@v4
         with:
           pattern: environments-artifact-*
@@ -164,7 +158,8 @@ jobs:
           aws-region: eu-west-1
           role-to-assume: arn:aws:iam::710450854638:role/github-action-gallery
 
-      - name: AWS S3 copies
+      - name: Publish environments
+        if: ${{ needs.build_environments.outputs.has_environments == 'true' }}
         run: |
           S3_BASE_URL="s3://downloads.robocorp.com/holotree/sema4ai"
           cd bin/publisher/environments
@@ -182,3 +177,34 @@ jobs:
               exit 1
             fi
           done
+
+      - name: Publish packages
+        if: ${{ needs.build_packages.outputs.has_packages == 'true' }}
+        run: |
+          echo "Updating Gallery S3"
+          S3_BASE_URL="s3://downloads.robocorp.com/gallery/actions"
+          cd bin/publisher/gallery
+          ls -la
+
+          # Copy the Action Package subdirectories. Note that since this is an update workflow,
+          # subdirectories will only contain packages which version's was actually bumped.
+          # cache-control max-age=31536000, because these should be immutable.
+          for dir in */; do
+            aws s3 cp "$dir" "$S3_BASE_URL/$dir" --recursive --cache-control max-age=31536000
+
+              returnCode=$?
+
+              # If the upload of any package fails, we want to break the workflow, as to not update the manifest,
+              # which should be the only source of truth.
+              # Even if some packages will be uploaded before other one fails, manifest won't include them,
+              # and therefore they won't be available in clients to download, and will be eligible to re-upload
+              # on the next Gallery update run.
+              if [ $returnCode -ne 0 ]; then
+                echo "Upload of '$dir' package failed, exiting..."
+                exit 1
+              fi
+
+          done
+
+          # Copy the updated manifest
+          aws s3 cp manifest.json $S3_BASE_URL/manifest.json --cache-control max-age=120 --content-type "text/plain"

--- a/.github/workflows/actions_s3_update_gallery.yml
+++ b/.github/workflows/actions_s3_update_gallery.yml
@@ -133,6 +133,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [build_packages, build_environments]
+    if: ${{ needs.build_packages.outputs.has_packages == 'true' || needs.build_environments.outputs.has_environments }}
     permissions:
       id-token: write # required by AWS aws-actions/configure-aws-credentials
       contents: read

--- a/.github/workflows/actions_s3_update_gallery.yml
+++ b/.github/workflows/actions_s3_update_gallery.yml
@@ -57,6 +57,7 @@ jobs:
 
   build_environments:
     needs: build_packages
+    if: ${{ needs.build_packages.outputs.has_packages == 'true' }}
     runs-on: ${{ matrix.os }}
     env:
       RCC_VERSION: v18.1.1

--- a/actions/browsing/package.yaml
+++ b/actions/browsing/package.yaml
@@ -5,7 +5,7 @@ name: Browsing
 description: Get information from websites, and interact with them.
 
 # Package version number, recommend using semver.org
-version: 1.0.1
+version: 1.0.2
 
 dependencies:
   conda-forge:
@@ -17,6 +17,7 @@ dependencies:
     - pydantic=2.7.4
     - robocorp-browser=2.3.3
     - requests=2.31.0
+    - robocorp-excel=0.4.4
 
 packaging:
   # By default, all files and folders in this directory are packaged when uploaded.

--- a/actions/browsing/package.yaml
+++ b/actions/browsing/package.yaml
@@ -5,7 +5,7 @@ name: Browsing
 description: Get information from websites, and interact with them.
 
 # Package version number, recommend using semver.org
-version: 1.0.0
+version: 1.0.1
 
 dependencies:
   conda-forge:

--- a/actions/browsing/package.yaml
+++ b/actions/browsing/package.yaml
@@ -5,7 +5,7 @@ name: Browsing
 description: Get information from websites, and interact with them.
 
 # Package version number, recommend using semver.org
-version: 1.0.1
+version: 1.0.0
 
 dependencies:
   conda-forge:

--- a/actions/browsing/package.yaml
+++ b/actions/browsing/package.yaml
@@ -5,7 +5,7 @@ name: Browsing
 description: Get information from websites, and interact with them.
 
 # Package version number, recommend using semver.org
-version: 1.0.2
+version: 1.0.0
 
 dependencies:
   conda-forge:
@@ -17,7 +17,6 @@ dependencies:
     - pydantic=2.7.4
     - robocorp-browser=2.3.3
     - requests=2.31.0
-    - robocorp-excel=0.4.4
 
 packaging:
   # By default, all files and folders in this directory are packaged when uploaded.

--- a/bin/publisher/build_updated_packages.py
+++ b/bin/publisher/build_updated_packages.py
@@ -40,7 +40,13 @@ def build_updated_packages():
     # We use manifest to build all the packages that have a version that is not yet published.
     # We want to skip not updated packages at this point already, as building a package can also take
     # a non-trivial amount of time.
-    build_action_packages(input_folder, zips_folder, action_server_path, published_manifest)
+    built_count = build_action_packages(input_folder, zips_folder, action_server_path, published_manifest)
+
+    # If no packages were built, there is no point in continuing. Manifest won't be created, and the pipeline
+    # will be able to leverage this to skip some of the jobs.
+    if built_count == 0:
+        print(f"\n No packages were built (no updates detected), manifest won't be created.")
+        return
 
     # Then, we extract all information needed to update the manifest from the package eligible for update.
     extract_all(zips_folder, gallery_actions_folder, rcc_path)

--- a/bin/publisher/build_updated_packages.py
+++ b/bin/publisher/build_updated_packages.py
@@ -20,7 +20,14 @@ def build_updated_packages():
     published_manifest_path = os.path.join(working_dir, "published_manifest.json")
 
     download_file("https://cdn.sema4.ai/gallery/actions/manifest.json", published_manifest_path)
-    published_manifest: Manifest = read_json_file(published_manifest_path)
+
+    published_manifest: Manifest
+
+    try:
+        published_manifest = read_json_file(published_manifest_path)
+    except Exception as e:
+        log_error('Reading published manifest failed, exiting...')
+        return
 
     # When updating the gallery, we assume that some packages has already been published - otherwise, we want to
     # skip the operation. This ensures that if manifest download fails for any reason, we don't end up replacing

--- a/bin/publisher/extractor.py
+++ b/bin/publisher/extractor.py
@@ -52,7 +52,7 @@ def extract_single_zip(zip_path: str, gallery_actions_folder: str, rcc_path: str
             try:
                 subprocess.run(hash_command, shell=True, check=True)
             except subprocess.CalledProcessError as e:
-                log_error(versioned_extract_path, f"Failed to run RCC on {package_yaml_path}: {str(e)}")
+                log_error(f"Failed to run RCC on {package_yaml_path}: {str(e)}", versioned_extract_path)
 
 
 def extract_all(zips_folder: str, gallery_actions_folder: str, rcc_path: str):

--- a/bin/publisher/manifest.py
+++ b/bin/publisher/manifest.py
@@ -1,7 +1,7 @@
 import os
 import hashlib
 import json
-from utils import read_file_contents, read_yaml_file, get_version_strings_from_package_info, read_json_file
+from utils import read_file_contents, read_yaml_file, get_version_strings_from_package_info
 from models import VersionInfo, PackageInfo, Manifest, ActionInfo
 
 
@@ -30,12 +30,12 @@ def generate_manifest(gallery_actions_folder: str, base_url: str) -> Manifest:
                     env_hash_path = os.path.join(version_path, "env.hash")
                     package_hash_path = os.path.join(version_path, "package.hash")
 
+                    # If reading of any file fails, we want to let it throw,
+                    # so it can be dealt with higher up if needed.
                     package_data = read_yaml_file(package_yaml_path)
                     actions = get_actions_info(metadata_path)
                     python_env_hash = read_file_contents(env_hash_path)
                     zip_hash = read_file_contents(package_hash_path)
-
-
 
                     version_info: VersionInfo = {
                         'version': package_data.get('version', version_dir),

--- a/bin/publisher/package_builder.py
+++ b/bin/publisher/package_builder.py
@@ -25,7 +25,7 @@ def build_single_package(sub_folder_path: str, zips_folder: str, action_server_p
             print(f"{sub_folder_path} package errored, will not be available to publish")
 
 
-def build_action_packages(input_folder: str, zips_folder: str, action_server_path: str, manifest: Manifest = None) -> None:
+def build_action_packages(input_folder: str, zips_folder: str, action_server_path: str, manifest: Manifest = None) -> int:
     """
     Iterates over all sub-folders in the input folder and builds action packages where package.yaml is found.
 
@@ -35,11 +35,16 @@ def build_action_packages(input_folder: str, zips_folder: str, action_server_pat
         action_server_path (str): The path to the action server executable.
         manifest (Manifest): The package manifest. If provided, versions already existing in the manifest
             will be skipped.
+
+    Returns:
+        built_count: number of built packages.
     """
 
     # Ensure the output directory exists
     if not os.path.exists(zips_folder):
         os.makedirs(zips_folder)
+
+    built_count = 0
 
     # Process each sub-folder in the main input folder
     for sub_folder_name in os.listdir(input_folder):
@@ -70,3 +75,6 @@ def build_action_packages(input_folder: str, zips_folder: str, action_server_pat
             # only then we build a package.
             if len(published_versions) == 0 or package_version not in published_versions:
                 build_single_package(sub_folder_path, zips_folder, action_server_path)
+                built_count += 1
+
+    return built_count

--- a/bin/publisher/package_builder.py
+++ b/bin/publisher/package_builder.py
@@ -21,7 +21,7 @@ def build_single_package(sub_folder_path: str, zips_folder: str, action_server_p
 
             subprocess.run(command, shell=True, check=True, cwd=sub_folder_path)
         except subprocess.CalledProcessError as e:
-            log_error(sub_folder_path, str(e))
+            log_error(str(e), sub_folder_path)
             print(f"{sub_folder_path} package errored, will not be available to publish")
 
 
@@ -54,7 +54,7 @@ def build_action_packages(input_folder: str, zips_folder: str, action_server_pat
             try:
                 package_data = read_yaml_file(os.path.join(sub_folder_path, "package.yaml"))
             except Exception as e:
-                log_error(f"Reading package.yaml from {sub_folder_path} failed with error {e}, skipping")
+                log_error(f"Reading package.yaml failed with error {e}, skipping", sub_folder_path)
                 continue
 
             published_versions: list[str] = []

--- a/bin/publisher/utils.py
+++ b/bin/publisher/utils.py
@@ -25,30 +25,27 @@ def sha256(filepath: str, hash_type: str = 'sha256') -> str:
     return hash_obj.hexdigest()
 
 
-def log_error(sub_folder_path: str, error_message: str) -> None:
+def log_error(error_message: str, sub_folder_path: str = None) -> None:
     with open("log.txt", "a") as log_file:
-        log_file.write(f"Error in folder {sub_folder_path}: {error_message}\n")
+        message = f'Error in folder {sub_folder_path}: ' if sub_folder_path else ''
+        message += f"{error_message}\n"
+
+        log_file.write(message)
 
 
 def read_file_contents(file_path: str) -> str:
-    if os.path.exists(file_path):
-        with open(file_path, 'r') as file:
-            return file.read().strip()
-    return ''
+    with open(file_path, 'r') as file:
+        return file.read().strip()
 
 
 def read_json_file(file_path: str) -> dict[str, Any]:
-    if os.path.exists(file_path):
-        with open(file_path, 'r') as file:
-            return json.load(file)
-    return {}
+    with open(file_path, 'r') as file:
+        return json.load(file)
 
 
 def read_yaml_file(file_path: str) -> dict[str, Any]:
-    if os.path.exists(file_path):
-        with open(file_path, 'r') as file:
-            return yaml.safe_load(file)
-    return {}
+    with open(file_path, 'r') as file:
+        return yaml.safe_load(file)
 
 
 def clear_folders(target_folder: str) -> None:


### PR DESCRIPTION
Moves environment publishing before gallery (and `manifest.json`), and improves dependencies between jobs:
- building environments will be skipped if there is no content under `bin/publisher/gallery`
- environments publish will be skipped (instead of failing) if there are no environments in `bin/publisher/environments`
- packages publish will be skipped (instead of failing) if there are no packages in `bin/publisher/gallery`