### PR TITLE
License and changelog minor fixes

### DIFF
--- a/actions/actions-bootstrapper/CHANGELOG.md
+++ b/actions/actions-bootstrapper/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [1.0.0] - 2024-07-25
 

--- a/actions/actions-bootstrapper/LICENSE
+++ b/actions/actions-bootstrapper/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Robocorp Technologies, Inc.
+   Copyright 2024 Sema4.ai, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/actions/agent-connector/CHANGELOG.md
+++ b/actions/agent-connector/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [1.0.0] - 2024-07-25
 

--- a/actions/agent-connector/LICENSE
+++ b/actions/agent-connector/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Robocorp Technologies, Inc.
+   Copyright 2024 Sema4.ai, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/actions/browsing/CHANGELOG.md
+++ b/actions/browsing/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
  
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
  
 ## [1.0.0] - 2024-07-04
  

--- a/actions/email/CHANGELOG.md
+++ b/actions/email/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
  
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
  
 ## [0.1.0] - 2024-07-09
  

--- a/actions/excel/CHANGELOG.md
+++ b/actions/excel/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
  
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [2.0.0] - 2024-07-10
 

--- a/actions/free-web-search/CHANGELOG.md
+++ b/actions/free-web-search/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
  
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
  
 ## [1.0.0] - 2024-07-04
  

--- a/actions/google-calendar/CHANGELOG.md
+++ b/actions/google-calendar/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
  
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
  
 ## [1.0.0] - 2024-07-09
  

--- a/actions/google-docs/CHANGELOG.md
+++ b/actions/google-docs/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
  
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
 
 
 ## [1.2.0] - 2025-07-11

--- a/actions/google-drive/CHANGELOG.md
+++ b/actions/google-drive/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
  
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
  
 ## [1.0.0] - 2024-07-09
  

--- a/actions/google-mail/CHANGELOG.md
+++ b/actions/google-mail/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
  
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
  
 ## [1.1.0] - 2024-07-09
 

--- a/actions/google-search/CHANGELOG.md
+++ b/actions/google-search/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
  
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
  
 ## [1.0.0] - 2024-07-04
  

--- a/actions/google-sheets/CHANGELOG.md
+++ b/actions/google-sheets/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
  
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
  
 ## [1.0.0] - 2024-07-04
  

--- a/actions/hubspot/CHANGELOG.md
+++ b/actions/hubspot/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
  
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [1.1.1] - 2024-07-26
  

--- a/actions/microsoft-sharepoint/CHANGELOG.md
+++ b/actions/microsoft-sharepoint/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
  
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
  
 ## [1.0.0] - 2024-07-04
  

--- a/actions/microsoft-sharepoint/LICENSE
+++ b/actions/microsoft-sharepoint/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Robocorp Technologies, Inc.
+   Copyright 2024 Sema4.ai, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/actions/pdf/CHANGELOG.md
+++ b/actions/pdf/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
  
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
  
 ## [0.1.0] - 2024-07-04
  

--- a/actions/slack/CHANGELOG.md
+++ b/actions/slack/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
  
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
  
 ## [1.0.0] - 2024-07-04
  

--- a/actions/vitality-lab-results/CHANGELOG.md
+++ b/actions/vitality-lab-results/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [1.0.0] - 2024-07-25
 

--- a/actions/vitality-medications/CHANGELOG.md
+++ b/actions/vitality-medications/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [1.0.0] - 2024-07-25
 

--- a/actions/vitality-workouts/CHANGELOG.md
+++ b/actions/vitality-workouts/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [1.0.0] - 2024-07-25
 

--- a/actions/wayback-machine/CHANGELOG.md
+++ b/actions/wayback-machine/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [1.0.0] - 2024-07-25
 

--- a/actions/wayback-machine/LICENSE
+++ b/actions/wayback-machine/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Robocorp Technologies, Inc.
+   Copyright 2024 Sema4.ai, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/actions/youtube/CHANGELOG.md
+++ b/actions/youtube/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
  
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
  
 ## [1.0.0] - 2024-07-04
  

--- a/actions/zendesk/CHANGELOG.md
+++ b/actions/zendesk/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [1.0.0] - 2024-07-09
 


### PR DESCRIPTION

## Description
Fixed Apache 2 license refer to Sema4.ai instead of Robocorp
Fixed changelog links to semver.org and keepachangelog.com to default to https instead of http.

## How can (was) this tested?

Only markdown and license file changes.
