### PR TITLE
Remove footer from email and add sender parameter

### DIFF
--- a/actions/email/CHANGELOG.md
+++ b/actions/email/CHANGELOG.md
@@ -1,18 +1,26 @@
 # Change Log
+
 All notable changes to this project will be documented in this file.
- 
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
- 
-## [0.1.0] - 2024-07-09
- 
-Draft version for testing.
- 
-### Added
-- Send email
- 
+
+## [0.1.1] - 2024-08-13
+
+Couple of fixes related sender email address and footer message.
+
 ### Changed
- 
-### Fixed
+
+- Sender email address given as action argument
 
 ### Removed
+
+- Fixed footer message regarding Sema4.ai
+
+## [0.1.0] - 2024-07-09
+
+Draft version for testing.
+
+### Added
+
+- Send email

--- a/actions/email/README.md
+++ b/actions/email/README.md
@@ -1,1 +1,27 @@
-# Email
+# Email sending
+
+Action Package for sending email using any SMTP service.
+
+Possible actions with this package are:
+
+- sending email
+
+## Prompts
+
+```
+Send email from sema4.tester@gmail.com to johndoe@domain.com. Body of the email should contain list of Sharepoint sites
+and subject would be "testing email action".
+```
+
+> The email has been sent successfully with the list of your SharePoint sites. If you need any further assistance, feel free to ask!
+
+## Authorization
+
+This action package uses SMTP authentication to login into SMTP server.
+
+Credentials needed are:
+
+    - the hostname of the SMTP server
+    - the port number of the SMTP server (commonly 587)
+    - the user account name
+    - the password for the account (could be a app password if possible)

--- a/actions/email/actions.py
+++ b/actions/email/actions.py
@@ -11,11 +11,10 @@ from email.mime.multipart import MIMEMultipart
 
 load_dotenv()
 
-message_footer = "\n\nStart building your Agents and AI Actions at https://sema4.ai"
-
 
 @action(is_consequential=False)
 def send_email(
+    sender: str,
     to: str,
     subject: str,
     body: str,
@@ -34,6 +33,7 @@ def send_email(
     check their spam folder.
 
     Args:
+        sender: email address of the sender
         to: email address(es) of the recipient(s)
         subject: subject of the email
         body: body of the email
@@ -60,16 +60,12 @@ def send_email(
     username = smtp_username.value
     password = smtp_password.value
 
-    # Email content
-    sender_email = "noreply@sema4ai.email"
-    subject = subject
-    body = body + message_footer
     # Create list of all recipients (including BCC)
     recipients = to.split(",")
 
     # Create MIME message
     message = MIMEMultipart()
-    message["From"] = sender_email
+    message["From"] = sender
     message["To"] = to
     message["Subject"] = subject
 
@@ -89,7 +85,7 @@ def send_email(
             server.starttls()  # Secure the connection
             server.login(username, password)
             text = message.as_string()
-            server.sendmail(sender_email, recipients, text)
+            server.sendmail(sender, recipients, text)
     except Exception as e:
         error_message = f"Email send error: {e}"
         print(error_message)

--- a/actions/email/package.yaml
+++ b/actions/email/package.yaml
@@ -2,10 +2,10 @@
 name: Email sending
 
 # Required: A description of what's in the action package
-description: Base actions needed to send emails using Sema4.ai service.
+description: Base actions needed to send emails using any SMTP service.
 
 # Package version number, recommend using semver.org
-version: 0.1.0
+version: 0.1.1
 
 dependencies:
   conda-forge:


### PR DESCRIPTION
## Description

Remove fixed "sema4.ai" footer and add sender email address as a parameter.

Link to the Linear Issue: [SMTP email sending for Koch](https://linear.app/sema4ai/issue/DEV-944/smtp-email-sending-for-koch)

## How can (was) this tested?

Tested with Sema4.ai Studio

## Screenshots (if needed)

## Checklist:

- [x] I have bumped the version number for the Action Package / Agent
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - README.md file
- [x] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added new unit tests that with the existing ones pass locally
