### PR TITLE
Should we add input json devdata for VS Code users in the repo?

### DIFF
--- a/actions/microsoft-calendar/devdata/input_get_mailbox_timezone.json
+++ b/actions/microsoft-calendar/devdata/input_get_mailbox_timezone.json
@@ -1,0 +1,13 @@
+{
+    "vscode:request:oauth2": {
+        "credentials": {
+            "type": "OAuth2Secret",
+            "scopes": [
+                "Calendars.Read", 
+                "Calendars.ReadWrite", 
+                "MailboxSettings.Read"
+            ],
+            "provider": "microsoft"
+        }
+    }
+}

--- a/actions/microsoft-calendar/devdata/input_list_calendars.json
+++ b/actions/microsoft-calendar/devdata/input_list_calendars.json
@@ -1,0 +1,13 @@
+{
+    "vscode:request:oauth2": {
+        "credentials": {
+            "type": "OAuth2Secret",
+            "scopes": [
+                "Calendars.Read", 
+                "Calendars.ReadWrite", 
+                "MailboxSettings.Read"
+            ],
+            "provider": "microsoft"
+        }
+    }
+}

--- a/actions/microsoft-calendar/devdata/input_list_events.json
+++ b/actions/microsoft-calendar/devdata/input_list_events.json
@@ -1,0 +1,18 @@
+{
+    "vscode:request:oauth2": {
+        "credentials": {
+            "type": "OAuth2Secret",
+            "scopes": [
+                "Calendars.Read", 
+                "Calendars.ReadWrite", 
+                "MailboxSettings.Read"
+            ],
+            "provider": "microsoft"
+        }
+    },
+    "query_params": {
+        "filter": ""
+    },
+    "timezone": "<timezone string from get_mailbox_timezone>",
+    "calendar_id": "<calendar_id from list_calendars>"
+}


### PR DESCRIPTION
## Description

Added input JSON devdata for microsoft-calendar action pack to see if this makes sense or not?

## How can (was) this tested?

Manual tests with VS Code v2.4.6 and the new OAuth2 support

Don't know if this make sense or not so just a draft for now, also would need to add the create_event and update_event jsons