### PR TITLE
FIX: Update 'microsoft-mail' package action 'list_messages' to always return 'id'

### DIFF
--- a/actions/microsoft-mail/CHANGELOG.md
+++ b/actions/microsoft-mail/CHANGELOG.md
@@ -5,19 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.0.0] - 2024-09-12
+## [1.0.1] - 2024-09-23
+
+Fix problem where `list_messages` response is missing `id` property.
+
+### Fixed
+
+Action `list_messages` will always return `id` property even if it
+is not specifically requested in the action call.
+
+## [1.0.0] - 2024-09-20
 
 First version published, changelog tracking starts.
 
 ### Added
 
-- Microsoft Entra ID (Oauth2) authentication for actions
-- Download a file
-- Upload a file
-- Search files
-- List all sites
-- Get lists for a site
-- Create a list for a site
+- Basic set of actions to handle emails for Outlook account.
 
 ### Changed
 

--- a/actions/microsoft-mail/microsoft_mail/email_action.py
+++ b/actions/microsoft-mail/microsoft_mail/email_action.py
@@ -77,6 +77,9 @@ def list_emails(
         if properties_to_return
         else []
     )
+    # Make sure that 'id' is always returned when keys are limited
+    if len(keys_to_return) > 0 and "id" not in keys_to_return:
+        keys_to_return.append("id")
     headers = build_headers(token)
     headers["ConsistencyLevel"] = "eventual"
     folders = []

--- a/actions/microsoft-mail/package.yaml
+++ b/actions/microsoft-mail/package.yaml
@@ -5,7 +5,7 @@ name: Microsoft Mail
 description: Actions for Microsoft 365 Outlook emails.
 
 # Package version number, recommend using semver.org
-version: 1.0.0
+version: 1.0.1
 
 dependencies:
   conda-forge:


### PR DESCRIPTION
## Description

The problem is that action `list_messages` can be called without key for the email (id) thus making returned information unusable by further email actions like forwarding or replying.

The fix will make sure that `id` is always returned even if it is not given as the requested parameter in the action call.

## How can (was) this tested?

Can be reproduced by using published `microsoft-mail` action `list_messages` by forcing parameter `properties_to_return: "subject,from,receivedDateTime"` to the action call. This way `id` parameter (key for the email) is not returned.

## Checklist:

- [x] I have bumped the version number for the Action Package / Agent
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - README.md file
- [x] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added new unit tests that with the existing ones pass locally
