### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,4 +24,4 @@ Please also list any relevant details for your test configuration:
 - [ ] I have made corresponding changes to the documentation - README.md file
 - [ ] I have updated the CHANGELOG.md file in correspondence with my changes
 - [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] Microsoft OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
+- [ ] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,4 +24,4 @@ Please also list any relevant details for your test configuration:
 - [ ] I have made corresponding changes to the documentation - README.md file
 - [ ] I have updated the CHANGELOG.md file in correspondence with my changes
 - [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] I have added new unit tests that with the existing ones pass locally
+- [ ] Microsoft OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)


### PR DESCRIPTION
I think we should drop unit test check from the list as our repository currently has no recommended way of implementing unit tests. We can add this check back when we do have a recommended way.

Instead, add a check related to Microsoft OAuth2 scopes.

We could also add check on whether scope requires admin consent or not.
