### PR TITLE
FIX Microsoft Mail action OAuth2 scopes

### DIFF
--- a/actions/microsoft-mail/CHANGELOG.md
+++ b/actions/microsoft-mail/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.2] - 2024-09-26
+
+Fix problems with action scopes.
+
 ## [1.0.1] - 2024-09-23
 
 Fix problem where `list_messages` response is missing `id` property.

--- a/actions/microsoft-mail/CHANGELOG.md
+++ b/actions/microsoft-mail/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.0.2] - 2024-09-26
 
-Fix problems with action scopes.
+Fix problems with action scopes. Improvements on error handling.
 
 ## [1.0.1] - 2024-09-23
 

--- a/actions/microsoft-mail/devdata/get_token_action.py
+++ b/actions/microsoft-mail/devdata/get_token_action.py
@@ -3,10 +3,12 @@ from msal import ConfidentialClientApplication
 import json
 from pathlib import Path
 import os
+import requests
 from urllib.parse import urlparse, parse_qs
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import webbrowser
 
+BASE_GRAPH_URL = "https://graph.microsoft.com/v1.0"
 
 devdata_directory = Path(__file__).absolute().parent
 load_dotenv(devdata_directory / ".env")
@@ -31,7 +33,7 @@ class AuthorizationHandler(BaseHTTPRequestHandler):
 
 def get_auth_code(auth_url):
     webbrowser.open(auth_url)
-    httpd = HTTPServer(("localhost", 5000), AuthorizationHandler)
+    httpd = HTTPServer(("localhost", 4567), AuthorizationHandler)
     httpd.handle_request()
     return httpd.auth_code
 
@@ -42,7 +44,7 @@ def get_microsoft_token() -> str:
     client_secret = os.getenv("MICROSOFT_CLIENT_SECRET")
     scopes = os.getenv("MICROSOFT_SCOPES")
 
-    redirect_uri = "http://localhost:5000/callback"
+    redirect_uri = os.getenv("MICROSOFT_REDIRECT_URI", "http://localhost:5000/callback")
     app = ConfidentialClientApplication(
         client_id,
         authority=f"https://login.microsoftonline.com/{tenant_id}",
@@ -57,22 +59,77 @@ def get_microsoft_token() -> str:
 
     if "access_token" in result:
         access_token = result["access_token"]
-        # Update the "access_token" in all the json files in devdata directory
-        for file in os.listdir(devdata_directory):
-            if file.endswith(".json"):
-                file_path = devdata_directory / file
-                with open(file_path, "r+") as json_file:
-                    data = json.load(json_file)
-                    if "token" in data and "access_token" in data["token"]:
-                        data["token"]["access_token"] = access_token
-                        json_file.seek(0)
-                        json.dump(data, json_file, indent=4)
-                        json_file.truncate()
+        # # Update the "access_token" in all the json files in devdata directory
+        # for file in os.listdir(devdata_directory):
+        #     if file.endswith(".json"):
+        #         file_path = devdata_directory / file
+        #         with open(file_path, "r+") as json_file:
+        #             data = json.load(json_file)
+        #             if "token" in data and "access_token" in data["token"]:
+        #                 data["token"]["access_token"] = access_token
+        #                 json_file.seek(0)
+        #                 json.dump(data, json_file, indent=4)
+        #                 json_file.truncate()
+        return access_token
     else:
         print(
             f"Error acquiring token: {result.get('error')}, {result.get('error_description')}"
         )
+        return None
+
+
+def build_headers(access_token):
+    return {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+    }
+
+
+def send_request(
+    method,
+    url,
+    req_name,
+    headers=None,
+    data=None,
+    params=None,
+):
+    """
+    Generalized request handler.
+
+    :param method: HTTP method (e.g., 'get', 'post').
+    :param url: URL for the request.
+    :param headers: Optional headers for the request.
+    :param data: Optional JSON data for 'post' requests.
+    :param params: Optional query parameters for 'get' requests.
+    :return: JSON response data if available.
+    :raises: RequestException for any request failures.
+    """
+    try:
+        query_url = url if BASE_GRAPH_URL in url else f"{BASE_GRAPH_URL}{url}"
+        response = requests.request(
+            method, query_url, headers=headers, json=data, params=params
+        )
+        response.raise_for_status()  # Raises a HTTPError for bad responses
+        if response.status_code not in [200, 201, 202, 204]:
+            raise ValueError(f"Error on '{req_name}': {response.text}")
+        # Check if the response has JSON content
+        if "application/json" in response.headers.get("Content-Type", ""):
+            return response.json()
+        return None
+    except Exception as e:
+        raise ValueError(f"Error on '{req_name}': {str(e)}")
+
+
+def _get_me(token):
+    # scope required: User.Read
+    headers = build_headers(token)
+    return send_request("get", "/me", "get me", headers=headers)
 
 
 if __name__ == "__main__":
-    get_microsoft_token()
+    access_token = get_microsoft_token()
+    if access_token:
+        print(f"Access token: {access_token}")
+        headers = build_headers(access_token)
+        response = _get_me(access_token)
+        print(response)

--- a/actions/microsoft-mail/devdata/input_list_emails.json
+++ b/actions/microsoft-mail/devdata/input_list_emails.json
@@ -1,6 +1,6 @@
 {
-    "search_query": "receivedDateTime le 2024-08-05",
-    "folder_to_search": "Processed Invoices",
+    "search_query": "receivedDateTime eq 2024-09-26",
+    "folder_to_search": "inbox",
     "properties_to_return": "subject,from,receivedDateTime",
     "vscode:request:oauth2": {
         "token": {

--- a/actions/microsoft-mail/microsoft_mail/email_action.py
+++ b/actions/microsoft-mail/microsoft_mail/email_action.py
@@ -39,7 +39,7 @@ from microsoft_mail.support import build_headers, send_request
 def list_emails(
     token: OAuth2Secret[
         Literal["microsoft"],
-        list[Literal["Mail.Read"]],
+        list[Literal["Mail.Read", "User.Read"]],
     ],
     search_query: str,
     folder_to_search: str = "inbox",
@@ -87,6 +87,8 @@ def list_emails(
     if folder_to_search:
         folders = folders or list_folders(token).result
         folder_found = _find_folder(folders, folder_to_search)
+        if folder_found is None:
+            raise ActionError(f"Folder '{folder_to_search}' not found.")
         folder_to_search_id = folder_found["id"]
         if len(search_query) > 0:
             search_query = (
@@ -135,7 +137,7 @@ def list_emails(
 def filter_by_recipients(
     token: OAuth2Secret[
         Literal["microsoft"],
-        list[Literal["Mail.Read"]],
+        list[Literal["Mail.Read", "User.Read"]],
     ],
     search_query: str = "*",
     from_: str = "",
@@ -438,7 +440,7 @@ def send_draft(
 def reply_to_email(
     token: OAuth2Secret[
         Literal["microsoft"],
-        list[Literal["Mail.Send"]],
+        list[Literal["Mail.Send", "Mail.Read"]],
     ],
     email_id: str,
     reply: Email,
@@ -583,7 +585,7 @@ def get_email_by_id(
 def list_folders(
     token: OAuth2Secret[
         Literal["microsoft"],
-        list[Literal["Mail.Read"]],
+        list[Literal["Mail.Read", "User.Read"]],
     ],
     account: str = "me",
 ) -> Response:
@@ -606,7 +608,7 @@ def list_folders(
 
 @action
 def subscribe_notifications(
-    token: OAuth2Secret[Literal["microsoft"], list[Literal["Mail.ReadWrite"]]],
+    token: OAuth2Secret[Literal["microsoft"], list[Literal["Mail.Read", "User.Read"]]],
     email_folder: str,
     webhook_url: str,
     expiration_date: str,
@@ -653,7 +655,7 @@ def subscribe_notifications(
 
 @action
 def delete_all_subscriptions(
-    token: OAuth2Secret[Literal["microsoft"], list[Literal["Mail.ReadWrite"]]]
+    token: OAuth2Secret[Literal["microsoft"], list[Literal["Mail.Read"]]]
 ) -> Response:
     """
     Delete all existing subscriptions.
@@ -678,7 +680,7 @@ def delete_all_subscriptions(
 
 @action
 def delete_subscription(
-    token: OAuth2Secret[Literal["microsoft"], list[Literal["Mail.ReadWrite"]]],
+    token: OAuth2Secret[Literal["microsoft"], list[Literal["Mail.Read"]]],
     subscription_id: str,
 ) -> Response:
     """
@@ -721,7 +723,7 @@ def get_subscriptions(
 
 @action
 def get_folder(
-    token: OAuth2Secret[Literal["microsoft"], list[Literal["Mail.Read"]]],
+    token: OAuth2Secret[Literal["microsoft"], list[Literal["Mail.Read", "User.Read"]]],
     folder_to_search: str,
     account: str,
 ) -> Response[dict]:

--- a/actions/microsoft-mail/microsoft_mail/email_action.py
+++ b/actions/microsoft-mail/microsoft_mail/email_action.py
@@ -51,7 +51,7 @@ def list_emails(
 
     When searching emails in a specific folder, the folder name should be provided in the 'folder_to_search' parameter and NOT in the 'search_query'.
 
-    Do NOT add to 'search_query' any conditions related to recipients ('to', 'cc', 'bcc' or 'from'). In that case use 'filter_by_recipients' action after this action.
+    Use action 'filter_by_recipients' if there are any conditions related to recipients ('to', 'cc', 'bcc' or 'from').
 
     For any date comparison use:
         - consider Monday as beginning of the week
@@ -440,7 +440,7 @@ def send_draft(
 def reply_to_email(
     token: OAuth2Secret[
         Literal["microsoft"],
-        list[Literal["Mail.Send", "Mail.Read"]],
+        list[Literal["Mail.Send", "Mail.ReadWrite"]],
     ],
     email_id: str,
     reply: Email,
@@ -462,23 +462,25 @@ def reply_to_email(
     if len(reply.body) == 0:
         raise ActionError("Reply cannot be empty.")
     headers = build_headers(token)
-    data = {}
-    if reply_to_all:
-        endpoint = "replyAll"
-        data["comment"] = reply.body
-    else:
-        endpoint = "reply"
-        existing_message = get_email_by_id(token, email_id).result
-        message_data = _set_message_data(reply, html_content, existing_message)
-        data["message"] = message_data
+    endpoint = "createReplyAll" if reply_to_all else "createReply"
+    reply_data = _set_message_data(reply, html_content, reply=True)
     reply_response = send_request(
         "post",
         f"/me/messages/{email_id}/{endpoint}",
         f"{endpoint} to email",
-        data=data,
+        data=reply_data,
         headers=headers,
     )
-    return Response(result=reply_response)
+    draft_message_id = reply_response["id"]
+    for attachment in reply.attachments.attachments:
+        add_attachment(token, draft_message_id, attachment)
+    send_request(
+        "post",
+        f"/me/messages/{draft_message_id}/send",
+        "send {endpoint} email",
+        headers=headers,
+    )
+    return Response(result="Reply sent successfully")
 
 
 @action(is_consequential=True)
@@ -608,7 +610,9 @@ def list_folders(
 
 @action
 def subscribe_notifications(
-    token: OAuth2Secret[Literal["microsoft"], list[Literal["Mail.Read", "User.Read"]]],
+    token: OAuth2Secret[
+        Literal["microsoft"], list[Literal["Mail.ReadWrite", "User.Read"]]
+    ],
     email_folder: str,
     webhook_url: str,
     expiration_date: str,
@@ -616,6 +620,8 @@ def subscribe_notifications(
 ) -> Response:
     """
     Subscribe to notifications for new messages in a specific folder.
+
+    Expiration date can be at maximum 72 hours to the future. Set that if user does not give specific date.
 
     Args:
         token: The OAuth2 token for authentication.
@@ -628,12 +634,14 @@ def subscribe_notifications(
         Response: Confirmation of successful subscription.
     """
     headers = build_headers(token)
-    if email_folder.lower() == "inbox":
-        target_folder = "Inbox"
+    folder = get_folder(token, email_folder, account)
+    if account.lower() == "me":
+        subscription_user = "/me"
     else:
-        target_folder = get_folder(token, email_folder, account)
+        subscription_user = f"users/{account}"
+    target_folder = folder.result["id"]
     subscription_resource = (
-        f"users/{account}/mailFolders('{target_folder['id']}')/messages"
+        f"{subscription_user}/mailFolders('{target_folder}')/messages"
     )
     data = {
         "changeType": "created",
@@ -655,7 +663,7 @@ def subscribe_notifications(
 
 @action
 def delete_all_subscriptions(
-    token: OAuth2Secret[Literal["microsoft"], list[Literal["Mail.Read"]]]
+    token: OAuth2Secret[Literal["microsoft"], list[Literal["Mail.ReadWrite"]]]
 ) -> Response:
     """
     Delete all existing subscriptions.
@@ -680,7 +688,7 @@ def delete_all_subscriptions(
 
 @action
 def delete_subscription(
-    token: OAuth2Secret[Literal["microsoft"], list[Literal["Mail.Read"]]],
+    token: OAuth2Secret[Literal["microsoft"], list[Literal["Mail.ReadWrite"]]],
     subscription_id: str,
 ) -> Response:
     """

--- a/actions/microsoft-mail/microsoft_mail/support.py
+++ b/actions/microsoft-mail/microsoft_mail/support.py
@@ -52,6 +52,7 @@ def send_request(
 
 
 def _get_me(token):
+    # scope required: User.Read
     headers = build_headers(token)
     return send_request("get", "/me", "get me", headers=headers)
 
@@ -142,6 +143,7 @@ def _set_message_data(
 
 
 def _get_folder_structure(token, account, folder_id=None):
+    # scope required: least Mail.ReadBasic, higher Mail.ReadWrite / Mail.Read
     headers = build_headers(token)
     if folder_id:
         url = f"/users/{account}/mailFolders/{folder_id}/childFolders"
@@ -166,6 +168,7 @@ def _get_folder_structure(token, account, folder_id=None):
 
 
 def _delete_subscription(subscription_id: str, headers: dict):
+    # scope required: least Mail.ReadBasic, higher Mail.Read
     send_request(
         "delete",
         f"/subscriptions/{subscription_id}",

--- a/actions/microsoft-mail/microsoft_mail/support.py
+++ b/actions/microsoft-mail/microsoft_mail/support.py
@@ -83,13 +83,11 @@ def _base64_attachment(attachment):
     return data
 
 
-def _set_message_data(
-    message: Email, html_content: bool, existing_message=None
-) -> dict:
-    data = existing_message or {}
+def _set_message_data(message: Email, html_content: bool, reply: bool = False) -> dict:
+    data = {}
     if message.subject:
         data["subject"] = message.subject
-    if message.body and not existing_message:
+    if message.body:
         data["body"] = {
             "contentType": "HTML" if html_content else "Text",
             "content": message.body,
@@ -137,9 +135,7 @@ def _set_message_data(
                 ),
             }
         }
-    if "toRecipients" in data.keys() and existing_message:
-        data["toRecipients"] = data["toRecipients"].extend(existing_message["sender"])
-    return data
+    return {"message": data} if reply else data
 
 
 def _get_folder_structure(token, account, folder_id=None):

--- a/actions/microsoft-mail/package.yaml
+++ b/actions/microsoft-mail/package.yaml
@@ -5,18 +5,18 @@ name: Microsoft Mail
 description: Actions for Microsoft 365 Outlook emails.
 
 # Package version number, recommend using semver.org
-version: 1.0.1
+version: 1.0.2
 
 dependencies:
   conda-forge:
     - python=3.10.14
     - python-dotenv=1.0.1
-    - uv=0.4.9
+    - uv=0.4.16
   pypi:
-    - sema4ai-actions=0.10.0
+    - sema4ai-actions=1.0.0
     - requests=2.32.3
     - msal=1.31.0
-    - pydantic=2.9.1
+    - pydantic=2.9.2
 
 packaging:
   # By default, all files and folders in this directory are packaged when uploaded.


### PR DESCRIPTION
## Description

The Sema4.ai OAuth2 client revealed that `list_emails` and `filter_recipients` actions missed necessary scopes basically to get `/me` endpoint result.

## How can (was) this tested?

Testing done with Studio using Sema4.ai OAuth2 client.

## Screenshots (if needed)

## Checklist:

- [x] I have bumped the version number for the Action Package / Agent
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - README.md file
- [x] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
