### PR TITLE
Update how 'get_email_by_id' handles email body

### DIFF
--- a/actions/microsoft-mail/CHANGELOG.md
+++ b/actions/microsoft-mail/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.3] - 2024-10-01
+
+Change `get_email_by_id` to return only `bodyPreview` by default.
+By new `show_full_body` parameter set to `True` the `body` of email can be
+still retrieved.
+
 ## [1.0.2] - 2024-09-26
 
 Fix problems with action scopes. Improvements on error handling.

--- a/actions/microsoft-mail/microsoft_mail/email_action.py
+++ b/actions/microsoft-mail/microsoft_mail/email_action.py
@@ -562,13 +562,20 @@ def get_email_by_id(
         list[Literal["Mail.Read"]],
     ],
     email_id: str,
+    show_full_body: bool = False,
 ) -> Response:
     """
     Get the details of a specific email.
 
+    By default shows email's body preview. If you want to see the full body,
+    set 'show_full_body' to True.
+
+    The full 'body' of the email might return too much information for the chat to handle.
+
     Args:
         token: OAuth2 token to use for the operation.
         email_id: The ID of the email to retrieve.
+        show_full_body: Whether to show the full body content.
 
     Returns:
         The message details.
@@ -580,6 +587,10 @@ def get_email_by_id(
         "get email",
         headers=headers,
     )
+    if show_full_body:
+        message.pop("bodyPreview", None)
+    else:
+        message.pop("body", None)
     return Response(result=message)
 
 

--- a/actions/microsoft-mail/package.yaml
+++ b/actions/microsoft-mail/package.yaml
@@ -5,7 +5,7 @@ name: Microsoft Mail
 description: Actions for Microsoft 365 Outlook emails.
 
 # Package version number, recommend using semver.org
-version: 1.0.2
+version: 1.0.3
 
 dependencies:
   conda-forge:


### PR DESCRIPTION
## Description

The action 'get_email_by_id' might return too much content for Studio chat to handle.

Added new parameter 'show_full_body' which is by default `False` thus removing `body` from the returned email object, when set to `True` the `body` is returned but `bodyPreview` will be then removed from the returned email object. 

## How can (was) this tested?

For example list 10 latest email received and then ask to get all those emails.

## Screenshots (if needed)

## Checklist:

- [ ] I have bumped the version number for the Action Package / Agent
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - README.md file
- [ ] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
