### PR TITLE
Fix google-sheets scopes and google drive list comments

### DIFF
--- a/actions/google-drive/CHANGELOG.md
+++ b/actions/google-drive/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.3] - 2024-10-04
+
+## Fixed
+
+- Enhanced functionality to allow searching for comments in a file by both name and ID.
+
 ## [1.0.2] - 2024-08-08
 
 ### Added

--- a/actions/google-drive/package.yaml
+++ b/actions/google-drive/package.yaml
@@ -5,7 +5,7 @@ name: Google Drive
 description: Interact with Google Drive resources - search files, get comments, get contents and more!
 
 # Package version number, recommend using semver.org
-version: 1.0.2
+version: 1.0.3
 
 dependencies:
   conda-forge:

--- a/actions/google-sheets/CHANGELOG.md
+++ b/actions/google-sheets/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.2] - 2024-10-04
+
+### Changed
+
+- Use `https://www.googleapis.com/auth/drive.file` scope instead of `https://www.googleapis.com/auth/drive` for creation.
+
 ## [1.0.1] - 2024-07-31
 
 Description changed.

--- a/actions/google-sheets/README.md
+++ b/actions/google-sheets/README.md
@@ -60,4 +60,4 @@ This action package uses Google OAuth2 flow to authenticate user.
 Scopes in use:
 
     - https://www.googleapis.com/auth/spreadsheets
-    - https://www.googleapis.com/auth/drive
+    - https://www.googleapis.com/auth/drive.file

--- a/actions/google-sheets/actions.py
+++ b/actions/google-sheets/actions.py
@@ -64,7 +64,7 @@ def create_spreadsheet(
         list[
             Literal[
                 "https://www.googleapis.com/auth/spreadsheets",
-                "https://www.googleapis.com/auth/drive",
+                "https://www.googleapis.com/auth/drive.file",
             ],
         ],
     ],
@@ -95,7 +95,7 @@ def create_worksheet(
         list[
             Literal[
                 "https://www.googleapis.com/auth/spreadsheets",
-                "https://www.googleapis.com/auth/drive",
+                "https://www.googleapis.com/auth/drive.file",
             ],
         ],
     ],
@@ -216,7 +216,7 @@ def add_sheet_rows(
         list[
             Literal[
                 "https://www.googleapis.com/auth/spreadsheets",
-                "https://www.googleapis.com/auth/drive",
+                "https://www.googleapis.com/auth/drive.file",
             ],
         ],
     ],
@@ -256,7 +256,7 @@ def update_sheet_rows(
         list[
             Literal[
                 "https://www.googleapis.com/auth/spreadsheets",
-                "https://www.googleapis.com/auth/drive",
+                "https://www.googleapis.com/auth/drive.file",
             ],
         ],
     ],

--- a/actions/google-sheets/package.yaml
+++ b/actions/google-sheets/package.yaml
@@ -5,7 +5,7 @@ name: Google Sheets
 description: Create and read spreadsheets. Add/update rows.
 
 # Package version number, recommend using semver.org
-version: 1.0.1
+version: 1.0.2
 
 dependencies:
   conda-forge:


### PR DESCRIPTION
Google-drive -> Enhanced functionality to allow searching for comments in a file by both name and ID.
Google-sheets -> Use `https://www.googleapis.com/auth/drive.file` scope instead of `https://www.googleapis.com/auth/drive` for creation.