### PR TITLE
`Slack`. Fix paging when creating conversation list cache

### DIFF
--- a/actions/slack/CHANGELOG.md
+++ b/actions/slack/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.2] - 2024-11-01
+
+### Fixed
+
+- Conversation list caching paging problem.
+
 ## [1.0.1] - 2024-10-08
 
 ### Changed

--- a/actions/slack/actions.py
+++ b/actions/slack/actions.py
@@ -60,7 +60,7 @@ def send_message_to_channel(
     """
     with _build_api_client(access_token) as client:
         response = client.chat_postMessage(
-            channel=get_conversation_id(channel_name, client=client), text=message
+            channel=f"#{channel_name}", text=message
         ).validate()
 
     return Response(result=bool(response.data.get("ok", False)))

--- a/actions/slack/actions.py
+++ b/actions/slack/actions.py
@@ -60,7 +60,7 @@ def send_message_to_channel(
     """
     with _build_api_client(access_token) as client:
         response = client.chat_postMessage(
-            channel=f"#{channel_name}", text=message
+            channel=get_conversation_id(channel_name, client=client), text=message
         ).validate()
 
     return Response(result=bool(response.data.get("ok", False)))

--- a/actions/slack/conversations.py
+++ b/actions/slack/conversations.py
@@ -5,7 +5,6 @@ from rapidfuzz.distance.Levenshtein import distance as levenshtein_distance
 from rapidfuzz.process import extract as rapidfuzz_extract
 from robocorp import log
 from slack_sdk import WebClient as SlackWebClient
-from slack_sdk.errors import SlackApiError
 from typing_extensions import Self
 
 

--- a/actions/slack/devdata/input_send_message_to_channel.json
+++ b/actions/slack/devdata/input_send_message_to_channel.json
@@ -5,7 +5,7 @@
             "inputValue": {
                 "channel_name": "#general",
                 "message": "Hello from Sema4 AI",
-                "access_token": "<specify-secret>"
+                "access_token": ""
             }
         }
     ],

--- a/actions/slack/package.yaml
+++ b/actions/slack/package.yaml
@@ -1,5 +1,5 @@
 # Required: A short name for the action package
-name: Slack
+name: XSlack
 
 # Required: A description of what's in the action package
 description: Prebuilt actions for reading and writing from/to Slack channels.

--- a/actions/slack/package.yaml
+++ b/actions/slack/package.yaml
@@ -1,11 +1,11 @@
 # Required: A short name for the action package
-name: XSlack
+name: Slack
 
 # Required: A description of what's in the action package
 description: Prebuilt actions for reading and writing from/to Slack channels.
 
 # Package version number, recommend using semver.org
-version: 1.0.1
+version: 1.0.2
 
 dependencies:
   conda-forge:


### PR DESCRIPTION
## Description

On `ConversationInfo.new()` in the `while True:` loop the `cursor` was always set to `None` in the beginning of the loop. While request indicated that `next_cursor` is available and proceeded to continue the loop the next request was again made by `None` cursor instead of new cursor. This ultimately resulted in the RateLimit error from Slack web client API.

## How can (was) this tested?

Was tested by running action `send_message_to_channel` in VSCode and in the Sema4.ai Studio.


## Screenshots (if needed)

## Checklist:

- [x] I have bumped the version number for the Action Package / Agent
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - README.md file
- [x] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
