### PR TITLE
Fix 'get_website_content' parameter handling and improve text cleanup

### DIFF
--- a/actions/browsing/CHANGELOG.md
+++ b/actions/browsing/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - 2024-11-18
+
+### Added
+
+- Improved text content clean up for all 'text' properties
+
+### Fixed
+
+- Fix how parameter 'user_agent' is handled for 'get_website_content' action
+- Set max timeout 5 seconds for waiting for 'networkidle', but continue actions regardless
+
 ## [1.0.2] - 2024-10-03
 
 ### Changed

--- a/actions/browsing/CHANGELOG.md
+++ b/actions/browsing/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- Improved text content clean up for all 'text' properties
+- Improved text content cleanup for all 'text' properties
 
 ### Fixed
 

--- a/actions/browsing/devdata/input_get_website_content.json
+++ b/actions/browsing/devdata/input_get_website_content.json
@@ -1,12 +1,25 @@
 {
     "inputs": [
         {
-            "inputName": "input-1",
+            "inputName": "user agent empty - sendgrid pricing",
             "inputValue": {
-                "url": "https://sema4.ai",
+                "url": "https://sendgrid.com/pricing/",
+                "user_agent": {}
+            }
+        },
+        {
+            "inputName": "user agent name empty - sema4.ai docs",
+            "inputValue": {
+                "url": "https://sema4.ai/docs",
                 "user_agent": {
                     "name": ""
                 }
+            }
+        },
+        {
+            "inputName": "no user agent - sema4.ai",
+            "inputValue": {
+                "url": "https://sema4.ai"
             }
         }
     ],

--- a/actions/browsing/models.py
+++ b/actions/browsing/models.py
@@ -83,6 +83,19 @@ class WebPage(BaseModel):
     form: Form
     links: Links
 
+    def calculate_total_size(self) -> int:
+        """Calculate the total size of all properties in bytes.
+
+        Returns:
+            The total size of the url, text_content, form, and links in bytes.
+        """
+        url_size = len(self.url.encode("utf-8"))
+        text_content_size = len(self.text_content.encode("utf-8"))
+        form_size = len(self.form.json().encode("utf-8"))
+        links_size = len(self.links.json().encode("utf-8"))
+
+        return url_size + text_content_size + form_size + links_size
+
 
 class DownloadedFile(BaseModel):
     content: str = Field(description="The content of the downloaded file")
@@ -98,7 +111,9 @@ class UserAgent(BaseModel):
 
     @model_validator(mode="before")
     def set_user_agent(cls, values):
-        if values["name"] == "":
+        if not values:
+            values = {"name": _get_random_user_agent()}
+        if not values["name"]:
             values["name"] = _get_random_user_agent()
         return values
 

--- a/actions/browsing/package.yaml
+++ b/actions/browsing/package.yaml
@@ -5,7 +5,7 @@ name: Browsing
 description: Get information from websites, and interact with them.
 
 # Package version number, recommend using semver.org
-version: 1.0.2
+version: 1.1.0
 
 dependencies:
   conda-forge:

--- a/actions/browsing/support.py
+++ b/actions/browsing/support.py
@@ -15,9 +15,7 @@ def _clean_text(text):
     # Replace multiple spaces and tabs with a single space
     text = re.sub(r"[ \t]+", " ", text)
     # Replace multiple line breaks (possibly separated by spaces) with a single line break
-    text = re.sub(
-        r"(\n[ \t]*){2,}", "\n", text
-    )  # Change here to match line breaks with spaces
+    text = re.sub(r"(\n[ \t]*){2,}", "\n", text)
     # Strip leading and trailing whitespace
     text = text.strip()
     return text


### PR DESCRIPTION
## Description

The `get_website_content` could be called without `user_agent` parameter or by setting its value to empty dictionary and these were not handled correctly by the action.

The response size of the same action could be considerable (unnecessarily) due to empty spaces and/or line breaks within text content.

- Improved text content cleanup for all `text` properties
- Fix how parameter `user_agent` is handled for the `get_website_content` action
- Set max timeout 5 seconds for waiting for `networkidle`, but continue actions regardless

## How can (was) this tested?

Tested with Sema4.ai VSCode extension and with Sema4.ai Studio.

## Screenshots (if needed)

## Checklist:

- [x] I have bumped the version number for the Action Package / Agent
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - README.md file
- [x] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
