### PR TITLE
Teams fix search teams and list channel messages

### DIFF
--- a/actions/microsoft-teams/CHANGELOG.md
+++ b/actions/microsoft-teams/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.2] - 2024-12-13
+
+### Fixed
+
+- team search by name typing issue
+- get channel messages limit issue
+
 ## [1.0.1] - 2024-10-07
 
 ### Fixed

--- a/actions/microsoft-teams/microsoft_teams/models.py
+++ b/actions/microsoft-teams/microsoft_teams/models.py
@@ -65,8 +65,8 @@ class AddUsersToTeamRequest(BaseModel):
 class GetChannelMessagesRequest(BaseModel):
     team_id: str = Field(..., description="The ID of the Microsoft Team.")
     channel_id: str = Field(..., description="The ID of the channel within the team.")
-    limit: Optional[int] = Field(
-        10, description="The number of messages to retrieve. Defaults to 10."
+    limit: int = Field(
+        ..., description="The number of messages to retrieve. Use 10 if not specified."
     )
 
 

--- a/actions/microsoft-teams/microsoft_teams/teams_get_actions.py
+++ b/actions/microsoft-teams/microsoft_teams/teams_get_actions.py
@@ -51,7 +51,7 @@ def search_team_by_name(
         list[Literal["Group.Read.All"]],
     ],
     search_request: TeamSearchRequest,
-) -> Response[dict]:
+) -> Response[list[dict]]:
     """
     Search for a Microsoft Team by its name.
 
@@ -193,11 +193,11 @@ def get_channel_messages(
     Get messages from a specific channel in a Microsoft Team. Message replies not included but you can use "get_message_replies" if needed.
 
     Args:
-        messages_request: Pydantic model containing the team ID, channel ID, and an optional limit for the number of messages to retrieve.
+        messages_request: Pydantic model containing the team ID, channel ID, and an limit for the number of messages to retrieve. Use 10 if not specified.
         token: OAuth2 token to use for the operation.
 
     Returns:
-        Result of the operation, including a list of parsed messages if successful.
+        Result of the operation.
     """
     headers = build_headers(token)
 

--- a/actions/microsoft-teams/package.yaml
+++ b/actions/microsoft-teams/package.yaml
@@ -5,7 +5,7 @@ name: Microsoft Teams
 description: Work with Microsoft Teams.
 
 # Package version number, recommend using semver.org
-version: 1.0.1
+version: 1.0.2
 
 dependencies:
   conda-forge:


### PR DESCRIPTION
### Description
Fixed invalid return type in search_team_by_name action, from dict to list. Fixed input limit issue in get_channel_messages action. 

### How can (was) this tested?
Published and tested with an agent in Sema4.ai Studio version 1.0.65.

Search Teams by name worked correctly and get_channel_messages limit also works correctly. 

### Screenshots (if needed)
Checklist:

- [x] I have bumped the version number for the Action Package / Agent
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - README.md file
- [x] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)


