### PR TITLE
Fix get_workbook_schema on user missing on creator or last_modified_by

### DIFF
--- a/actions/excel/CHANGELOG.md
+++ b/actions/excel/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.1.2] - 2025-01-14
+
+### Fixed
+
+- The `get_workbook_schema` fail if workbook "creator" or "last modified" user is missing
+
 ## [3.1.1] - 2025-01-09
 
 ### Changed

--- a/actions/excel/actions.py
+++ b/actions/excel/actions.py
@@ -421,11 +421,19 @@ def get_workbook_schema(file_path: str) -> Response[Schema]:
     try:
         workbook = load_workbook(filename=path, read_only=True)
         created = UserAndTime(
-            user=workbook.properties.creator.encode("utf-8"),
+            user=(
+                workbook.properties.creator.encode("utf-8")
+                if workbook.properties.creator
+                else ""
+            ),
             time=workbook.properties.created,
         )
         last_modified = UserAndTime(
-            user=workbook.properties.last_modified_by.encode("utf-8"),
+            user=(
+                workbook.properties.last_modified_by.encode("utf-8")
+                if workbook.properties.last_modified_by
+                else ""
+            ),
             time=workbook.properties.modified,
         )
         for sheet_name in workbook.sheetnames:

--- a/actions/excel/package.yaml
+++ b/actions/excel/package.yaml
@@ -5,7 +5,7 @@ name: Excel
 description: Create, read and update sheets on local Excel files.
 
 # Package version number, recommend using semver.org
-version: 3.1.1
+version: 3.1.2
 
 # The version of the `package.yaml` format.
 spec-version: v2


### PR DESCRIPTION
## Description

`'NoneType' object has no attribute 'encode'` when workbook does not have `last_modified_by` user information.

## How can (was) this tested?

Tested in Studio with workbook which has not been modified.

## Screenshots (if needed)

## Checklist:

- [x] I have bumped the version number for the Action Package / Agent
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - README.md file
- [x] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
