### PR TITLE
Microsoft Mail: Add `save_attachments` to `get_email_by_id`

### DIFF
--- a/actions/microsoft-mail/CHANGELOG.md
+++ b/actions/microsoft-mail/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add parameters `save_attachments` and `make_dirs` to action `get_email_by_id`.
   The former can be given `downloads` as value and then attachments will be saved
-  to target machine Downloads folder.
+  to user's Downloads folder.
 
 ## [1.1.1] - 2025-01-09
 

--- a/actions/microsoft-mail/CHANGELOG.md
+++ b/actions/microsoft-mail/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.0] - 2025-01-21
+
+### Add
+
+- Add parameters `save_attachments` and `make_dirs` to action `get_email_by_id`.
+  The former can be given `downloads` as value and then attachments will be saved
+  to target machine Downloads folder.
+
 ## [1.1.1] - 2025-01-09
 
 ### Changed

--- a/actions/microsoft-mail/README.md
+++ b/actions/microsoft-mail/README.md
@@ -22,6 +22,7 @@ Currently supporting:
 - Getting a list of active subscriptions.
 - Retrieving details of a specific folder in the user's mailbox.
 - Flagging emails in the user's mailbox.
+- Saving attachments of an email.
 
 ## Prompt Examples
 

--- a/actions/microsoft-mail/devdata/input_get_email_by_id.json
+++ b/actions/microsoft-mail/devdata/input_get_email_by_id.json
@@ -53,6 +53,43 @@
                     }
                 }
             }
+        },
+        {
+            "inputName": "save attachments to custom directory and create the directory if it doesn't exist",
+            "inputValue": {
+                "email_id": "",
+                "show_full_body": false,
+                "save_attachments": "e:\\temp\\xyz",
+                "make_dirs": true,
+                "vscode:request:oauth2": {
+                    "token": {
+                        "type": "OAuth2Secret",
+                        "provider": "microsoft",
+                        "scopes": [
+                            "Mail.Read"
+                        ],
+                        "access_token": ""
+                    }
+                }
+            }
+        },
+        {
+            "inputName": "save attachments to custom directory fails because the directory doesn't exist",
+            "inputValue": {
+                "email_id": "",
+                "show_full_body": false,
+                "save_attachments": "e:\\temp\\xyz2",
+                "vscode:request:oauth2": {
+                    "token": {
+                        "type": "OAuth2Secret",
+                        "provider": "microsoft",
+                        "scopes": [
+                            "Mail.Read"
+                        ],
+                        "access_token": ""
+                    }
+                }
+            }
         }
     ],
     "metadata": {
@@ -61,7 +98,8 @@
         "schemaDescription": [
             "email_id: string: The unique identifier of the email to retrieve.",
             "show_full_body: boolean: Whether to show the full body content.",
-            "save_attachments: string: Whether to save the attachments to the local file system."
+            "save_attachments: string: Whether to save the attachments to the local file system.",
+            "make_dirs: boolean: Whether to create the directory for saving attachments if it doesn't exist."
         ],
         "managedParamsSchemaDescription": {
             "token": {
@@ -75,6 +113,6 @@
         },
         "inputFileVersion": "v3",
         "kind": "action",
-        "actionSignature": "action/args: \"token: OAuth2Secret[Literal['microsoft'], list[Literal['Mail.Read']]], email_id: str, show_full_body: bool=False, save_attachments: str=None\""
+        "actionSignature": "action/args: \"token: OAuth2Secret[Literal['microsoft'], list[Literal['Mail.Read']]], email_id: str, show_full_body: bool=False, save_attachments: str=None, make_dirs: bool=False\""
     }
 }

--- a/actions/microsoft-mail/devdata/input_get_email_by_id.json
+++ b/actions/microsoft-mail/devdata/input_get_email_by_id.json
@@ -1,0 +1,80 @@
+{
+    "inputs": [
+        {
+            "inputName": "save attachments to current directory",
+            "inputValue": {
+                "email_id": "",
+                "show_full_body": false,
+                "save_attachments": ".",
+                "vscode:request:oauth2": {
+                    "token": {
+                        "type": "OAuth2Secret",
+                        "provider": "microsoft",
+                        "scopes": [
+                            "Mail.Read"
+                        ],
+                        "access_token": ""
+                    }
+                }
+            }
+        },
+        {
+            "inputName": "save attachments to Downloads directory",
+            "inputValue": {
+                "email_id": "",
+                "show_full_body": false,
+                "save_attachments": "downloads",
+                "vscode:request:oauth2": {
+                    "token": {
+                        "type": "OAuth2Secret",
+                        "provider": "microsoft",
+                        "scopes": [
+                            "Mail.Read"
+                        ],
+                        "access_token": ""
+                    }
+                }
+            }
+        },
+        {
+            "inputName": "save attachments to custom directory",
+            "inputValue": {
+                "email_id": "",
+                "show_full_body": false,
+                "save_attachments": "e:\\temp",
+                "vscode:request:oauth2": {
+                    "token": {
+                        "type": "OAuth2Secret",
+                        "provider": "microsoft",
+                        "scopes": [
+                            "Mail.Read"
+                        ],
+                        "access_token": ""
+                    }
+                }
+            }
+        }
+    ],
+    "metadata": {
+        "actionName": "get_email_by_id",
+        "actionRelativePath": "microsoft_mail/email_action.py",
+        "schemaDescription": [
+            "email_id: string: The unique identifier of the email to retrieve.",
+            "show_full_body: boolean: Whether to show the full body content.",
+            "save_attachments: string: Whether to save the attachments to the local file system."
+        ],
+        "managedParamsSchemaDescription": {
+            "token": {
+                "type": "OAuth2Secret",
+                "description": "OAuth2 token to use for the operation.",
+                "provider": "microsoft",
+                "scopes": [
+                    "Mail.Read"
+                ]
+            }
+        },
+        "inputFileVersion": "v3",
+        "kind": "action",
+        "actionSignature": "action/args: \"token: OAuth2Secret[Literal['microsoft'], list[Literal['Mail.Read']]], email_id: str, show_full_body: bool=False, save_attachments: str=None\""
+    }
+}

--- a/actions/microsoft-mail/package.yaml
+++ b/actions/microsoft-mail/package.yaml
@@ -5,7 +5,7 @@ name: Microsoft Mail
 description: Actions for Microsoft 365 Outlook emails.
 
 # Package version number, recommend using semver.org
-version: 1.1.1
+version: 1.2.0
 
 # The version of the `package.yaml` format.
 spec-version: v2


### PR DESCRIPTION
## Description

Add the possibility of saving email attachments to a local folder. 

How added parameter `save_attachments` works:
- by default will save into the current working directory.
- if the value `downloads` is given then attachments are saved in the user's Downloads folder
- can be given local file path, on `make_dirs=True` this directory structure will be created if it does not exist

## How can (was) this tested?

Tested in VS Code and in the Studio.

## Screenshots (if needed)

## Checklist:

- [x] I have bumped the version number for the Action Package / Agent
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - README.md file
- [x] I have updated the CHANGELOG.md file in correspondence with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
