### PR TITLE
Add manifest_sai.json to the S3 bucket

### DIFF
--- a/.github/workflows/actions_s3_init_gallery.yml
+++ b/.github/workflows/actions_s3_init_gallery.yml
@@ -196,3 +196,6 @@ jobs:
 
           # Copy the updated manifest
           aws s3 cp manifest.json $S3_BASE_URL/manifest.json --cache-control max-age=120 --content-type "text/plain"
+          
+          # Copy the updated manifest_sai.json
+          aws s3 cp manifest_sai.json $S3_BASE_URL/manifest_sai.json --cache-control max-age=120 --content-type "text/plain"

--- a/.github/workflows/actions_s3_update_gallery.yml
+++ b/.github/workflows/actions_s3_update_gallery.yml
@@ -210,3 +210,6 @@ jobs:
 
           # Copy the updated manifest
           aws s3 cp manifest.json $S3_BASE_URL/manifest.json --cache-control max-age=120 --content-type "text/plain"
+
+          # Copy the updated manifest_sai.json
+          aws s3 cp manifest_sai.json $S3_BASE_URL/manifest_sai.json --cache-control max-age=120 --content-type "text/plain"


### PR DESCRIPTION
## Overview

Make manifest_sai.json available on S3 and in turn on CDN to be able to use from SAI Server

## Related PR

- https://github.com/Sema4AI/gallery/pull/120
