### PR TITLE
Add GitHub Actions for manifest_sai.json and Clean Up Workflow

### DIFF
--- a/.github/workflows/actions_s3_init_gallery.yml
+++ b/.github/workflows/actions_s3_init_gallery.yml
@@ -196,6 +196,3 @@ jobs:
 
           # Copy the updated manifest
           aws s3 cp manifest.json $S3_BASE_URL/manifest.json --cache-control max-age=120 --content-type "text/plain"
-          
-          # Copy the updated manifest_sai.json
-          aws s3 cp manifest_sai.json $S3_BASE_URL/manifest_sai.json --cache-control max-age=120 --content-type "text/plain"

--- a/.github/workflows/actions_s3_init_gallery_sai.yml
+++ b/.github/workflows/actions_s3_init_gallery_sai.yml
@@ -1,0 +1,39 @@
+name: Actions - Update manifest_sai.json
+
+on:
+  workflow_dispatch:
+    # Enables manual triggering via GitHub Actions
+
+jobs:
+  publish_manifest:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required by AWS aws-actions/configure-aws-credentials
+      contents: read
+    env:
+      RCC_VERSION: v18.1.1
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build Gallery
+        run: |
+          cd bin
+          curl -L -o rcc "https://cdn.sema4.ai/rcc/releases/${{ env.RCC_VERSION }}/linux64/rcc"
+          chmod +x rcc
+          ./rcc run -r publisher/robot.yaml -t "Build all packages"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: eu-west-1
+          role-to-assume: arn:aws:iam::710450854638:role/github-action-gallery
+
+      - name: Publish manifest_sai.json
+        run: |
+          S3_BASE_URL="s3://downloads.robocorp.com/gallery/actions"
+          cd bin/publisher/gallery
+          
+          # Copy only the manifest_sai.json
+          aws s3 cp manifest_sai.json $S3_BASE_URL/manifest_sai.json --cache-control max-age=120 --content-type "text/plain"

--- a/bin/publisher/build_updated_packages.py
+++ b/bin/publisher/build_updated_packages.py
@@ -4,6 +4,7 @@ from robocorp.tasks import task
 
 from actions_manifest import (
     generate_actions_manifest,
+    generate_actions_manifest_for_sai,
     generate_consolidated_manifest,
     save_manifest,
 )
@@ -82,6 +83,8 @@ def build_updated_packages():
     # one later on in the pipeline.
     update_manifest = generate_actions_manifest(gallery_actions_folder, base_url)
 
+    update_manifest_for_sai = generate_actions_manifest_for_sai(gallery_actions_folder, base_url)
+
     # We consolidate existing manifest with the updates, getting a manifest including updated packages.
     new_manifest: ActionsManifest = generate_consolidated_manifest(
         published_manifest, update_manifest
@@ -91,7 +94,7 @@ def build_updated_packages():
 
     # Write manifests to file.
     save_manifest(new_manifest, os.path.join(gallery_actions_folder, "manifest.json"))
-
+    save_manifest(update_manifest_for_sai, os.path.join(gallery_actions_folder, "manifest_for_sai.json"))
 
 if __name__ == "__main__":
     build_updated_packages()


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for publishing `manifest_sai.json` and performs a cleanup of the existing workflows.

### Changes Made:
1. **New Workflow**: 
   - Added a new workflow file `.github/workflows/actions_s3_init_gallery_sai.yml` that:
     - Allows manual triggering via `workflow_dispatch`.
     - Publishes `manifest_sai.json` to the specified S3 bucket after building the gallery.

2. **Cleanup Existing Workflow**:
   - Removed the redundant copy command for `manifest_sai.json` in the existing workflow `.github/workflows/actions_s3_init_gallery.yml`.

3. **Updated Python Script**:
   - Modified `bin/publisher/build_updated_packages.py` to include a new function to generate the `manifest_sai.json`.

### Purpose:
These changes streamline the process of managing manifests by separating the publishing logic for `manifest.json` and `manifest_sai.json`, ensuring a clearer and more maintainable workflow structure.

### Next Steps:
- Review the new workflow for correctness.
- Test the actions to ensure they publish the manifests as expected.