### PR TITLE
Excel. Fix how chat file is created when using create_workbook

### DIFF
--- a/actions/excel/CHANGELOG.md
+++ b/actions/excel/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [4.0.1] - 2025-02-17
+
+### Fixed
+
+- The `create_workbook` needs to create temporary file for attaching that as a chat file
+
 ## [4.0.0] - 2025-02-17
 
 ### Changed

--- a/actions/excel/package.yaml
+++ b/actions/excel/package.yaml
@@ -5,7 +5,7 @@ name: Excel
 description: Create, read and update sheets on local Excel files.
 
 # Package version number, recommend using semver.org
-version: 4.0.0
+version: 4.0.1
 
 # The version of the `package.yaml` format.
 spec-version: v2


### PR DESCRIPTION
## Description

The action `create_workbook` logic was incorrect when new file needs to be created into Agent chat.

## How can (was) this tested?

Tested with Studio v1.2.0-alpha9

## Screenshots (if needed)

## Checklist:

- [x] I have bumped the version number for the Action Package / Agent
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - README.md file
- [x] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
