### PR TITLE
Moved the cortex analyst and search query configs to secrets

### DIFF
--- a/actions/snowflake-cortex/CHANGELOG.md
+++ b/actions/snowflake-cortex/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.1] - 2025-02-25
+
+### Changed
+
+- Changed Cortex Search and Analyst actions to use Secrets for parameters, instead of relying them to be passed as strings by an agent based on Runbook instructions.
+- Updated Snowflake dependencies to latest versions
+
+### Fixed
+
+- Changed the input parameter `columns` for the `cortex_search` action to be always required.
+
 ## [1.0.0] - 2025-02-20
 
 - First version published, changelog tracking starts.

--- a/actions/snowflake-cortex/README.md
+++ b/actions/snowflake-cortex/README.md
@@ -19,18 +19,20 @@ Executes searches against your Cortex Search service with:
 - Result limiting
 - Flexible filtering options
 
-### Cortex Search: Runbook Additions
+### Cortex Search: Configuration
 
-Before using these actions, you need to specify the search service name and the correct database and schema to execute queries against.
+When using the actions, you need to configure several secrets for authentication and service configuration. These include:
+- Search Service Name
+- Warehouse
+- Database
+- Schema
 
-The Search Service specifies which search index to use for executing search operations. It's crucial for Cortex Search to know where to look for relevant data. *In your Runbook, replace the following with the right values for your environment.*
+These values are stored as secrets in your Sema4.ai Studio or Control Room, and requested from you when creating or deploying the agent. Snowflake has a great [tutorial](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-search/tutorials/cortex-search-tutorial-1-search) for setting up a Cortex Search service using Airbnb data as an example. If you have completed this tutorial, you can use the values from the tutorial as the secrets for the actions.
 
-```text
-Service Name: AIRBNB_SVC
-Warehouse: COMPUTE_WH
-Database: CORTEX_SEARCH_TUTORIAL_DB
-Schema: PUBLIC
-```
+- Service Name: "AIRBNB_SVC"
+- Warehouse: "COMPUTE_WH" (this depends on your Snowflake account and may be different)
+- Database: "CORTEX_SEARCH_TUTORIAL_DB"
+- Schema: "PUBLIC"
 
 ### Cortex Analyst Integration
 
@@ -46,20 +48,19 @@ Provides direct query execution capabilities against Snowflake:
 - Parameter support
 - Warehouse/Database/Schema configuration
 
-#### Cortex Analyst Runbook Additions
+#### Cortex Analyst Configuration
 
-Before using these actions, you need to specify the correct location of your semantic model file and the correct database and schema to execute queries against.
+When using these actions, you need to configure several secrets:
+- Semantic Model File location
+- Warehouse
+- Database
+- Schema
 
-The Semantic Model File defines the structure and relationships of your data, enabling Cortex Analyst to understand your data context.
+These values are stored in your Sema4.ai Studio or Control Room and requested from you when creating or deploying the agent.
 
-```text
-Semantic Model File: "@PRODUCTION_RESULTS.PUBLIC.STAGE1/oil_gas.yml"
-```
+Example values:
 
-To ensure your queries are executed against the correct database and schema, add the following to your runbook:
-
-```text
-Warehouse: COMPUTE_WH
-Database: PRODUCTION_RESULTS
-Schema: PUBLIC
-```
+- Semantic Model File: "@PRODUCTION_RESULTS.PUBLIC.STAGE1/oil_gas.yml"
+- Warehouse: COMPUTE_WH
+- Database: PRODUCTION_RESULTS
+- Schema: PUBLIC

--- a/actions/snowflake-cortex/devdata/input_cortex_analyst_message.json
+++ b/actions/snowflake-cortex/devdata/input_cortex_analyst_message.json
@@ -3,21 +3,25 @@
         {
             "inputName": "input-1",
             "inputValue": {
-                "semantic_model_file": "@PRODUCTION_RESULTS.PUBLIC.STAGE1/oil_gas.yml",
-                "message": "Get total production of oil in all data"
+                "message": "Show me the top 5 oil producing wells by production volume over time.",
+                "semantic_model_file": "@PRODUCTION_RESULTS.PUBLIC.STAGE1/oil_gas.yml"
             }
         }
     ],
     "metadata": {
         "actionName": "cortex_analyst_message",
-        "actionRelativePath": "cortex-actions.py",
+        "actionRelativePath": "cortex_actions.py",
         "schemaDescription": [
-            "semantic_model_file: string: The semantic model file to use.",
             "message: string: The message to send to the Cortex Analyst."
         ],
-        "managedParamsSchemaDescription": {},
+        "managedParamsSchemaDescription": {
+            "semantic_model_file": {
+                "type": "Secret",
+                "description": "The semantic model file to use."
+            }
+        },
         "inputFileVersion": "v3",
         "kind": "action",
-        "actionSignature": "action/args: 'semantic_model_file: str, message: str'"
+        "actionSignature": "action/args: 'semantic_model_file: Secret, message: str'"
     }
 }

--- a/actions/snowflake-cortex/devdata/input_cortex_get_search_specification.json
+++ b/actions/snowflake-cortex/devdata/input_cortex_get_search_specification.json
@@ -4,24 +4,36 @@
             "inputName": "input-1",
             "inputValue": {
                 "warehouse": "COMPUTE_WH",
-                "database": "PRODUCTION_RESULTS",
+                "database": "CORTEX_SEARCH_TUTORIAL_DB",
                 "schema": "PUBLIC",
-                "service": "OIL_GAS_SVC"
+                "service": "AIRBNB_SVC"
             }
         }
     ],
     "metadata": {
         "actionName": "cortex_get_search_specification",
-        "actionRelativePath": "cortex-actions.py",
-        "schemaDescription": [
-            "warehouse: string: The warehouse to use.",
-            "database: string: The database to use.",
-            "schema: string: The schema to use.",
-            "service: string: The service to use."
-        ],
-        "managedParamsSchemaDescription": {},
+        "actionRelativePath": "cortex_actions.py",
+        "schemaDescription": [],
+        "managedParamsSchemaDescription": {
+            "warehouse": {
+                "type": "Secret",
+                "description": "The warehouse to use."
+            },
+            "database": {
+                "type": "Secret",
+                "description": "The database to use."
+            },
+            "schema": {
+                "type": "Secret",
+                "description": "The schema to use."
+            },
+            "service": {
+                "type": "Secret",
+                "description": "The service to use."
+            }
+        },
         "inputFileVersion": "v3",
         "kind": "action",
-        "actionSignature": "action/args: 'warehouse: str, database: str, schema: str, service: str'"
+        "actionSignature": "action/args: 'warehouse: Secret, database: Secret, schema: Secret, service: Secret'"
     }
 }

--- a/actions/snowflake-cortex/devdata/input_cortex_search.json
+++ b/actions/snowflake-cortex/devdata/input_cortex_search.json
@@ -3,33 +3,49 @@
         {
             "inputName": "input-1",
             "inputValue": {
-                "query": "Get notes from the december meeting",
+                "query": "Can you analyze the different types of cancellation policies by room type?",
+                "columns": [
+                    "room_type",
+                    "cancellation_policy"
+                ],
+                "limit": 10,
                 "warehouse": "COMPUTE_WH",
-                "database": "PRODUCTION_RESULTS",
+                "database": "CORTEX_SEARCH_TUTORIAL_DB",
                 "schema": "PUBLIC",
-                "service": "OIL_GAS_SVC",
-                "columns": ["CONTENTS"],
-                "filter": null,
-                "limit": 5
+                "service": "AIRBNB_SVC"
             }
         }
     ],
     "metadata": {
         "actionName": "cortex_search",
-        "actionRelativePath": "cortex-actions.py",
+        "actionRelativePath": "cortex_actions.py",
         "schemaDescription": [
             "query: string: The query to execute",
-            "warehouse: string: The warehouse to use",
-            "database: string: The database to use",
-            "schema: string: The schema to use",
-            "service: string: The service to use",
-            "columns: string: The columns to return, optional, defaults to None",
+            "columns: array: The columns to return",
+            "columns.0: string: The columns to return",
             "filter: string: The filter to apply, optional, defaults to None",
             "limit: integer: The limit to apply, optional, defaults to 5"
         ],
-        "managedParamsSchemaDescription": {},
+        "managedParamsSchemaDescription": {
+            "warehouse": {
+                "type": "Secret",
+                "description": "Your Snowflake virtual warehouse to use for queries"
+            },
+            "database": {
+                "type": "Secret",
+                "description": "Your Snowflake database to use for queries"
+            },
+            "schema": {
+                "type": "Secret",
+                "description": "Your Snowflake schema to use for queries"
+            },
+            "service": {
+                "type": "Secret",
+                "description": "The name of the Cortex Search service to use"
+            }
+        },
         "inputFileVersion": "v3",
         "kind": "action",
-        "actionSignature": "action/args: 'query: str, warehouse: str, database: str, schema: str, service: str, columns: list | None=None, filter: dict | None=None, limit: int=5'"
+        "actionSignature": "action/args: 'query: str, warehouse: Secret, database: Secret, schema: Secret, service: Secret, columns: list, filter: dict | None=None, limit: int=5'"
     }
 }

--- a/actions/snowflake-cortex/package.yaml
+++ b/actions/snowflake-cortex/package.yaml
@@ -5,7 +5,7 @@ name: Snowflake Cortex
 description: Snowflake Cortex AI Actions
 
 # Package version number, recommend using semver.org
-version: 1.0.0
+version: 1.0.1
 
 spec-version: v2
 
@@ -21,10 +21,10 @@ dependencies:
   - tabulate=0.9.0
   - PyYAML=6.0.2
   - openpyxl=3.2.0b1
-  - snowflake=1.0.4
-  - snowflake-snowpark-python=1.27.0
+  - snowflake=1.0.5
+  - snowflake-snowpark-python=1.28.0
   - pyjwt=2.10.1
-  - streamlit=1.42.0
+  - streamlit=1.42.2
 
 packaging:
   # By default, all files and folders in this directory are packaged when uploaded.

--- a/actions/snowflake-cortex/snowflake_actions.py
+++ b/actions/snowflake-cortex/snowflake_actions.py
@@ -1,13 +1,12 @@
-from sema4ai.actions import Response, action
-
+from sema4ai.actions import Response, action, Secret
 from utils import execute_query
 
 @action
 def snowflake_execute_query(
     query: str,
-    warehouse: str = "",
-    database: str = None,
-    schema: str = None,
+    warehouse: Secret,
+    database: Secret,
+    schema: Secret,
     numeric_args: list = None,
 ) -> Response[list]:
     """
@@ -15,9 +14,9 @@ def snowflake_execute_query(
 
     Args:
         query: The query to execute.
-        database: The database to use.
-        schema: The schema to use.
-        warehouse: The warehouse to use.
+        database: Your Snowflake database to use for queries.
+        schema: Your Snowflake schema to use for queries.
+        warehouse: Your Snowflake virtual warehouse to use for queries.
         numeric_args: A list of numeric arguments to pass to the query.
 
     Returns:
@@ -26,7 +25,7 @@ def snowflake_execute_query(
 
     return Response(result=execute_query(
                 query=query,
-                warehouse=warehouse,
-                database=database,
-                schema=schema,
+                warehouse=warehouse.value,
+                database=database.value,
+                schema=schema.value,
                 numeric_args=numeric_args))

--- a/actions/snowflake-cortex/utils.py
+++ b/actions/snowflake-cortex/utils.py
@@ -1,13 +1,9 @@
-from contextlib import closing, contextmanager
-
-import snowflake.connector
-from sema4ai.data import get_snowflake_connection_details
 import os
-import json
-from datetime import datetime
 import pandas as pd
+import snowflake.connector
 from pathlib import Path
-
+from contextlib import closing, contextmanager
+from sema4ai.data import get_snowflake_connection_details
 
 def _get_snowflake_connection(
     role: str = None,


### PR DESCRIPTION
## Description

We relied on user to write things like Warehouse name, Database, Schema and service identifier to Runbook, and then agent passing them as args to actions. This is risky and unreliable, and people tend to not even realise they are in the runbook. This PR moves those configs to be action secrets.

## How can (was) this tested?

Tested locally on my Studio with template agents for cortex search and analyst.

## Screenshots (if needed)

![Screenshot 2025-02-25 at 09 30 45](https://github.com/user-attachments/assets/bfd9b171-76e8-4907-8a44-bc7edaf05763)
![Screenshot 2025-02-25 at 09 27 31](https://github.com/user-attachments/assets/0609e1b5-bf7b-46f2-9633-db844caa20fa)

## Checklist:

- [X] I have bumped the version number for the Action Package / Agent
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation - README.md file
- [X] I have updated the CHANGELOG.md file in correspondence with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [N/A] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
