### PR TITLE
Updated Cortex templates to use latest action pack with secrets

### DIFF
--- a/agents/cortex-analyst-example/CHANGELOG.md
+++ b/agents/cortex-analyst-example/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.0.2] - 2025-02-25
+
+- Updated the Snowflake package version to 1.0.1 that uses secrets
+- Removed configurations such as warehouse, database, and schema from the runbook
+
 ## [0.0.1] - 2025-02-20
 
 - First version published, changelog tracking starts.

--- a/agents/cortex-analyst-example/actions/Sema4.ai/snowflake-cortex/CHANGELOG.md
+++ b/agents/cortex-analyst-example/actions/Sema4.ai/snowflake-cortex/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.1] - 2025-02-25
+
+### Changed
+
+- Changed Cortex Search and Analyst actions to use Secrets for parameters, instead of relying them to be passed as strings by an agent based on Runbook instructions.
+- Updated Snowflake dependencies to latest versions
+
+### Fixed
+
+- Changed the input parameter `columns` for the `cortex_search` action to be always required.
+
 ## [1.0.0] - 2025-02-20
 
 - First version published, changelog tracking starts.

--- a/agents/cortex-analyst-example/actions/Sema4.ai/snowflake-cortex/README.md
+++ b/agents/cortex-analyst-example/actions/Sema4.ai/snowflake-cortex/README.md
@@ -19,18 +19,20 @@ Executes searches against your Cortex Search service with:
 - Result limiting
 - Flexible filtering options
 
-### Cortex Search: Runbook Additions
+### Cortex Search: Configuration
 
-Before using these actions, you need to specify the search service name and the correct database and schema to execute queries against.
+When using the actions, you need to configure several secrets for authentication and service configuration. These include:
+- Search Service Name
+- Warehouse
+- Database
+- Schema
 
-The Search Service specifies which search index to use for executing search operations. It's crucial for Cortex Search to know where to look for relevant data. *In your Runbook, replace the following with the right values for your environment.*
+These values are stored as secrets in your Sema4.ai Studio or Control Room, and requested from you when creating or deploying the agent. Snowflake has a great [tutorial](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-search/tutorials/cortex-search-tutorial-1-search) for setting up a Cortex Search service using Airbnb data as an example. If you have completed this tutorial, you can use the values from the tutorial as the secrets for the actions.
 
-```text
-Service Name: AIRBNB_SVC
-Warehouse: COMPUTE_WH
-Database: CORTEX_SEARCH_TUTORIAL_DB
-Schema: PUBLIC
-```
+- Service Name: "AIRBNB_SVC"
+- Warehouse: "COMPUTE_WH" (this depends on your Snowflake account and may be different)
+- Database: "CORTEX_SEARCH_TUTORIAL_DB"
+- Schema: "PUBLIC"
 
 ### Cortex Analyst Integration
 
@@ -46,20 +48,19 @@ Provides direct query execution capabilities against Snowflake:
 - Parameter support
 - Warehouse/Database/Schema configuration
 
-#### Cortex Analyst Runbook Additions
+#### Cortex Analyst Configuration
 
-Before using these actions, you need to specify the correct location of your semantic model file and the correct database and schema to execute queries against.
+When using these actions, you need to configure several secrets:
+- Semantic Model File location
+- Warehouse
+- Database
+- Schema
 
-The Semantic Model File defines the structure and relationships of your data, enabling Cortex Analyst to understand your data context.
+These values are stored in your Sema4.ai Studio or Control Room and requested from you when creating or deploying the agent.
 
-```text
-Semantic Model File: "@PRODUCTION_RESULTS.PUBLIC.STAGE1/oil_gas.yml"
-```
+Example values:
 
-To ensure your queries are executed against the correct database and schema, add the following to your runbook:
-
-```text
-Warehouse: COMPUTE_WH
-Database: PRODUCTION_RESULTS
-Schema: PUBLIC
-```
+- Semantic Model File: "@PRODUCTION_RESULTS.PUBLIC.STAGE1/oil_gas.yml"
+- Warehouse: COMPUTE_WH
+- Database: PRODUCTION_RESULTS
+- Schema: PUBLIC

--- a/agents/cortex-analyst-example/actions/Sema4.ai/snowflake-cortex/devdata/input_cortex_analyst_message.json
+++ b/agents/cortex-analyst-example/actions/Sema4.ai/snowflake-cortex/devdata/input_cortex_analyst_message.json
@@ -3,21 +3,25 @@
         {
             "inputName": "input-1",
             "inputValue": {
-                "semantic_model_file": "@PRODUCTION_RESULTS.PUBLIC.STAGE1/oil_gas.yml",
-                "message": "Get total production of oil in all data"
+                "message": "Show me the top 5 oil producing wells by production volume over time.",
+                "semantic_model_file": "@PRODUCTION_RESULTS.PUBLIC.STAGE1/oil_gas.yml"
             }
         }
     ],
     "metadata": {
         "actionName": "cortex_analyst_message",
-        "actionRelativePath": "cortex-actions.py",
+        "actionRelativePath": "cortex_actions.py",
         "schemaDescription": [
-            "semantic_model_file: string: The semantic model file to use.",
             "message: string: The message to send to the Cortex Analyst."
         ],
-        "managedParamsSchemaDescription": {},
+        "managedParamsSchemaDescription": {
+            "semantic_model_file": {
+                "type": "Secret",
+                "description": "The semantic model file to use."
+            }
+        },
         "inputFileVersion": "v3",
         "kind": "action",
-        "actionSignature": "action/args: 'semantic_model_file: str, message: str'"
+        "actionSignature": "action/args: 'semantic_model_file: Secret, message: str'"
     }
 }

--- a/agents/cortex-analyst-example/actions/Sema4.ai/snowflake-cortex/devdata/input_cortex_get_search_specification.json
+++ b/agents/cortex-analyst-example/actions/Sema4.ai/snowflake-cortex/devdata/input_cortex_get_search_specification.json
@@ -4,24 +4,36 @@
             "inputName": "input-1",
             "inputValue": {
                 "warehouse": "COMPUTE_WH",
-                "database": "PRODUCTION_RESULTS",
+                "database": "CORTEX_SEARCH_TUTORIAL_DB",
                 "schema": "PUBLIC",
-                "service": "OIL_GAS_SVC"
+                "service": "AIRBNB_SVC"
             }
         }
     ],
     "metadata": {
         "actionName": "cortex_get_search_specification",
-        "actionRelativePath": "cortex-actions.py",
-        "schemaDescription": [
-            "warehouse: string: The warehouse to use.",
-            "database: string: The database to use.",
-            "schema: string: The schema to use.",
-            "service: string: The service to use."
-        ],
-        "managedParamsSchemaDescription": {},
+        "actionRelativePath": "cortex_actions.py",
+        "schemaDescription": [],
+        "managedParamsSchemaDescription": {
+            "warehouse": {
+                "type": "Secret",
+                "description": "The warehouse to use."
+            },
+            "database": {
+                "type": "Secret",
+                "description": "The database to use."
+            },
+            "schema": {
+                "type": "Secret",
+                "description": "The schema to use."
+            },
+            "service": {
+                "type": "Secret",
+                "description": "The service to use."
+            }
+        },
         "inputFileVersion": "v3",
         "kind": "action",
-        "actionSignature": "action/args: 'warehouse: str, database: str, schema: str, service: str'"
+        "actionSignature": "action/args: 'warehouse: Secret, database: Secret, schema: Secret, service: Secret'"
     }
 }

--- a/agents/cortex-analyst-example/actions/Sema4.ai/snowflake-cortex/devdata/input_cortex_search.json
+++ b/agents/cortex-analyst-example/actions/Sema4.ai/snowflake-cortex/devdata/input_cortex_search.json
@@ -3,33 +3,49 @@
         {
             "inputName": "input-1",
             "inputValue": {
-                "query": "Get notes from the december meeting",
+                "query": "Can you analyze the different types of cancellation policies by room type?",
+                "columns": [
+                    "room_type",
+                    "cancellation_policy"
+                ],
+                "limit": 10,
                 "warehouse": "COMPUTE_WH",
-                "database": "PRODUCTION_RESULTS",
+                "database": "CORTEX_SEARCH_TUTORIAL_DB",
                 "schema": "PUBLIC",
-                "service": "OIL_GAS_SVC",
-                "columns": ["CONTENTS"],
-                "filter": null,
-                "limit": 5
+                "service": "AIRBNB_SVC"
             }
         }
     ],
     "metadata": {
         "actionName": "cortex_search",
-        "actionRelativePath": "cortex-actions.py",
+        "actionRelativePath": "cortex_actions.py",
         "schemaDescription": [
             "query: string: The query to execute",
-            "warehouse: string: The warehouse to use",
-            "database: string: The database to use",
-            "schema: string: The schema to use",
-            "service: string: The service to use",
-            "columns: string: The columns to return, optional, defaults to None",
+            "columns: array: The columns to return",
+            "columns.0: string: The columns to return",
             "filter: string: The filter to apply, optional, defaults to None",
             "limit: integer: The limit to apply, optional, defaults to 5"
         ],
-        "managedParamsSchemaDescription": {},
+        "managedParamsSchemaDescription": {
+            "warehouse": {
+                "type": "Secret",
+                "description": "Your Snowflake virtual warehouse to use for queries"
+            },
+            "database": {
+                "type": "Secret",
+                "description": "Your Snowflake database to use for queries"
+            },
+            "schema": {
+                "type": "Secret",
+                "description": "Your Snowflake schema to use for queries"
+            },
+            "service": {
+                "type": "Secret",
+                "description": "The name of the Cortex Search service to use"
+            }
+        },
         "inputFileVersion": "v3",
         "kind": "action",
-        "actionSignature": "action/args: 'query: str, warehouse: str, database: str, schema: str, service: str, columns: list | None=None, filter: dict | None=None, limit: int=5'"
+        "actionSignature": "action/args: 'query: str, warehouse: Secret, database: Secret, schema: Secret, service: Secret, columns: list, filter: dict | None=None, limit: int=5'"
     }
 }

--- a/agents/cortex-analyst-example/actions/Sema4.ai/snowflake-cortex/package.yaml
+++ b/agents/cortex-analyst-example/actions/Sema4.ai/snowflake-cortex/package.yaml
@@ -5,7 +5,7 @@ name: Snowflake Cortex
 description: Snowflake Cortex AI Actions
 
 # Package version number, recommend using semver.org
-version: 1.0.0
+version: 1.0.1
 
 spec-version: v2
 
@@ -21,10 +21,10 @@ dependencies:
   - tabulate=0.9.0
   - PyYAML=6.0.2
   - openpyxl=3.2.0b1
-  - snowflake=1.0.4
-  - snowflake-snowpark-python=1.27.0
+  - snowflake=1.0.5
+  - snowflake-snowpark-python=1.28.0
   - pyjwt=2.10.1
-  - streamlit=1.42.0
+  - streamlit=1.42.2
 
 packaging:
   # By default, all files and folders in this directory are packaged when uploaded.

--- a/agents/cortex-analyst-example/actions/Sema4.ai/snowflake-cortex/snowflake_actions.py
+++ b/agents/cortex-analyst-example/actions/Sema4.ai/snowflake-cortex/snowflake_actions.py
@@ -1,13 +1,12 @@
-from sema4ai.actions import Response, action
-
+from sema4ai.actions import Response, action, Secret
 from utils import execute_query
 
 @action
 def snowflake_execute_query(
     query: str,
-    warehouse: str = "",
-    database: str = None,
-    schema: str = None,
+    warehouse: Secret,
+    database: Secret,
+    schema: Secret,
     numeric_args: list = None,
 ) -> Response[list]:
     """
@@ -15,9 +14,9 @@ def snowflake_execute_query(
 
     Args:
         query: The query to execute.
-        database: The database to use.
-        schema: The schema to use.
-        warehouse: The warehouse to use.
+        database: Your Snowflake database to use for queries.
+        schema: Your Snowflake schema to use for queries.
+        warehouse: Your Snowflake virtual warehouse to use for queries.
         numeric_args: A list of numeric arguments to pass to the query.
 
     Returns:
@@ -26,7 +25,7 @@ def snowflake_execute_query(
 
     return Response(result=execute_query(
                 query=query,
-                warehouse=warehouse,
-                database=database,
-                schema=schema,
+                warehouse=warehouse.value,
+                database=database.value,
+                schema=schema.value,
                 numeric_args=numeric_args))

--- a/agents/cortex-analyst-example/actions/Sema4.ai/snowflake-cortex/utils.py
+++ b/agents/cortex-analyst-example/actions/Sema4.ai/snowflake-cortex/utils.py
@@ -1,13 +1,9 @@
-from contextlib import closing, contextmanager
-
-import snowflake.connector
-from sema4ai.data import get_snowflake_connection_details
 import os
-import json
-from datetime import datetime
 import pandas as pd
+import snowflake.connector
 from pathlib import Path
-
+from contextlib import closing, contextmanager
+from sema4ai.data import get_snowflake_connection_details
 
 def _get_snowflake_connection(
     role: str = None,

--- a/agents/cortex-analyst-example/agent-spec.yaml
+++ b/agents/cortex-analyst-example/agent-spec.yaml
@@ -14,7 +14,7 @@ agent-package:
     - name: Snowflake Cortex
       organization: Sema4.ai
       type: folder
-      version: 1.0.0
+      version: 1.0.1
       whitelist: cortex_analyst_message,snowflake_execute_query
       path: Sema4.ai/snowflake-cortex
     knowledge: []

--- a/agents/cortex-analyst-example/runbook.md
+++ b/agents/cortex-analyst-example/runbook.md
@@ -12,21 +12,6 @@ To help you with the analysis, you have Cortex Analyst at your disposal. Here's 
 - Use ILIKE operators for string matching unless an exact match is required.
 - Execute the SQL query using the appropriate action when the user confirms.
 
-## Configuration
-This section outlines the key configuration parameters used for Cortex Analysis and SQL execution. These parameters ensure that you're accessing the correct data sources.
-
-### Semantic Model File
-The Semantic Model File defines the structure and relationships of the data you're working with. It's crucial for Cortex Analyst to understand the context of your data. Replace this with the path to your semantic model.
-
-Semantic Model File: "@PRODUCTION_RESULTS.PUBLIC.STAGE1/oil_gas.yml"
-
-### Parameters for SQL Execution
-These parameters specify where and how SQL queries should be executed. Replace these values with the correct values for your environment.
-
-Warehouse: COMPUTE_WH
-Database: PRODUCTION_RESULTS
-Schema: PUBLIC
-
 ## Steps
 1. **Understand the User's Request:** 
    - Listen carefully to the user's question or request for analysis.

--- a/agents/cortex-search-example/CHANGELOG.md
+++ b/agents/cortex-search-example/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+# [0.0.2] - 2025-02-25
+
+- Updated the Snowflake package version to 1.0.1 that uses secrets
+- Removed configurations such as warehouse, database, and schema from the runbook
+
+
 ## [0.0.1] - 2025-02-20
 
 - First version published, changelog tracking starts.

--- a/agents/cortex-search-example/actions/Sema4.ai/snowflake-cortex/CHANGELOG.md
+++ b/agents/cortex-search-example/actions/Sema4.ai/snowflake-cortex/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.1] - 2025-02-25
+
+### Changed
+
+- Changed Cortex Search and Analyst actions to use Secrets for parameters, instead of relying them to be passed as strings by an agent based on Runbook instructions.
+- Updated Snowflake dependencies to latest versions
+
+### Fixed
+
+- Changed the input parameter `columns` for the `cortex_search` action to be always required.
+
 ## [1.0.0] - 2025-02-20
 
 - First version published, changelog tracking starts.

--- a/agents/cortex-search-example/actions/Sema4.ai/snowflake-cortex/README.md
+++ b/agents/cortex-search-example/actions/Sema4.ai/snowflake-cortex/README.md
@@ -19,18 +19,20 @@ Executes searches against your Cortex Search service with:
 - Result limiting
 - Flexible filtering options
 
-### Cortex Search: Runbook Additions
+### Cortex Search: Configuration
 
-Before using these actions, you need to specify the search service name and the correct database and schema to execute queries against.
+When using the actions, you need to configure several secrets for authentication and service configuration. These include:
+- Search Service Name
+- Warehouse
+- Database
+- Schema
 
-The Search Service specifies which search index to use for executing search operations. It's crucial for Cortex Search to know where to look for relevant data. *In your Runbook, replace the following with the right values for your environment.*
+These values are stored as secrets in your Sema4.ai Studio or Control Room, and requested from you when creating or deploying the agent. Snowflake has a great [tutorial](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-search/tutorials/cortex-search-tutorial-1-search) for setting up a Cortex Search service using Airbnb data as an example. If you have completed this tutorial, you can use the values from the tutorial as the secrets for the actions.
 
-```text
-Service Name: AIRBNB_SVC
-Warehouse: COMPUTE_WH
-Database: CORTEX_SEARCH_TUTORIAL_DB
-Schema: PUBLIC
-```
+- Service Name: "AIRBNB_SVC"
+- Warehouse: "COMPUTE_WH" (this depends on your Snowflake account and may be different)
+- Database: "CORTEX_SEARCH_TUTORIAL_DB"
+- Schema: "PUBLIC"
 
 ### Cortex Analyst Integration
 
@@ -46,20 +48,19 @@ Provides direct query execution capabilities against Snowflake:
 - Parameter support
 - Warehouse/Database/Schema configuration
 
-#### Cortex Analyst Runbook Additions
+#### Cortex Analyst Configuration
 
-Before using these actions, you need to specify the correct location of your semantic model file and the correct database and schema to execute queries against.
+When using these actions, you need to configure several secrets:
+- Semantic Model File location
+- Warehouse
+- Database
+- Schema
 
-The Semantic Model File defines the structure and relationships of your data, enabling Cortex Analyst to understand your data context.
+These values are stored in your Sema4.ai Studio or Control Room and requested from you when creating or deploying the agent.
 
-```text
-Semantic Model File: "@PRODUCTION_RESULTS.PUBLIC.STAGE1/oil_gas.yml"
-```
+Example values:
 
-To ensure your queries are executed against the correct database and schema, add the following to your runbook:
-
-```text
-Warehouse: COMPUTE_WH
-Database: PRODUCTION_RESULTS
-Schema: PUBLIC
-```
+- Semantic Model File: "@PRODUCTION_RESULTS.PUBLIC.STAGE1/oil_gas.yml"
+- Warehouse: COMPUTE_WH
+- Database: PRODUCTION_RESULTS
+- Schema: PUBLIC

--- a/agents/cortex-search-example/actions/Sema4.ai/snowflake-cortex/devdata/input_cortex_analyst_message.json
+++ b/agents/cortex-search-example/actions/Sema4.ai/snowflake-cortex/devdata/input_cortex_analyst_message.json
@@ -3,21 +3,25 @@
         {
             "inputName": "input-1",
             "inputValue": {
-                "semantic_model_file": "@PRODUCTION_RESULTS.PUBLIC.STAGE1/oil_gas.yml",
-                "message": "Get total production of oil in all data"
+                "message": "Show me the top 5 oil producing wells by production volume over time.",
+                "semantic_model_file": "@PRODUCTION_RESULTS.PUBLIC.STAGE1/oil_gas.yml"
             }
         }
     ],
     "metadata": {
         "actionName": "cortex_analyst_message",
-        "actionRelativePath": "cortex-actions.py",
+        "actionRelativePath": "cortex_actions.py",
         "schemaDescription": [
-            "semantic_model_file: string: The semantic model file to use.",
             "message: string: The message to send to the Cortex Analyst."
         ],
-        "managedParamsSchemaDescription": {},
+        "managedParamsSchemaDescription": {
+            "semantic_model_file": {
+                "type": "Secret",
+                "description": "The semantic model file to use."
+            }
+        },
         "inputFileVersion": "v3",
         "kind": "action",
-        "actionSignature": "action/args: 'semantic_model_file: str, message: str'"
+        "actionSignature": "action/args: 'semantic_model_file: Secret, message: str'"
     }
 }

--- a/agents/cortex-search-example/actions/Sema4.ai/snowflake-cortex/devdata/input_cortex_get_search_specification.json
+++ b/agents/cortex-search-example/actions/Sema4.ai/snowflake-cortex/devdata/input_cortex_get_search_specification.json
@@ -4,24 +4,36 @@
             "inputName": "input-1",
             "inputValue": {
                 "warehouse": "COMPUTE_WH",
-                "database": "PRODUCTION_RESULTS",
+                "database": "CORTEX_SEARCH_TUTORIAL_DB",
                 "schema": "PUBLIC",
-                "service": "OIL_GAS_SVC"
+                "service": "AIRBNB_SVC"
             }
         }
     ],
     "metadata": {
         "actionName": "cortex_get_search_specification",
-        "actionRelativePath": "cortex-actions.py",
-        "schemaDescription": [
-            "warehouse: string: The warehouse to use.",
-            "database: string: The database to use.",
-            "schema: string: The schema to use.",
-            "service: string: The service to use."
-        ],
-        "managedParamsSchemaDescription": {},
+        "actionRelativePath": "cortex_actions.py",
+        "schemaDescription": [],
+        "managedParamsSchemaDescription": {
+            "warehouse": {
+                "type": "Secret",
+                "description": "The warehouse to use."
+            },
+            "database": {
+                "type": "Secret",
+                "description": "The database to use."
+            },
+            "schema": {
+                "type": "Secret",
+                "description": "The schema to use."
+            },
+            "service": {
+                "type": "Secret",
+                "description": "The service to use."
+            }
+        },
         "inputFileVersion": "v3",
         "kind": "action",
-        "actionSignature": "action/args: 'warehouse: str, database: str, schema: str, service: str'"
+        "actionSignature": "action/args: 'warehouse: Secret, database: Secret, schema: Secret, service: Secret'"
     }
 }

--- a/agents/cortex-search-example/actions/Sema4.ai/snowflake-cortex/devdata/input_cortex_search.json
+++ b/agents/cortex-search-example/actions/Sema4.ai/snowflake-cortex/devdata/input_cortex_search.json
@@ -3,33 +3,49 @@
         {
             "inputName": "input-1",
             "inputValue": {
-                "query": "Get notes from the december meeting",
+                "query": "Can you analyze the different types of cancellation policies by room type?",
+                "columns": [
+                    "room_type",
+                    "cancellation_policy"
+                ],
+                "limit": 10,
                 "warehouse": "COMPUTE_WH",
-                "database": "PRODUCTION_RESULTS",
+                "database": "CORTEX_SEARCH_TUTORIAL_DB",
                 "schema": "PUBLIC",
-                "service": "OIL_GAS_SVC",
-                "columns": ["CONTENTS"],
-                "filter": null,
-                "limit": 5
+                "service": "AIRBNB_SVC"
             }
         }
     ],
     "metadata": {
         "actionName": "cortex_search",
-        "actionRelativePath": "cortex-actions.py",
+        "actionRelativePath": "cortex_actions.py",
         "schemaDescription": [
             "query: string: The query to execute",
-            "warehouse: string: The warehouse to use",
-            "database: string: The database to use",
-            "schema: string: The schema to use",
-            "service: string: The service to use",
-            "columns: string: The columns to return, optional, defaults to None",
+            "columns: array: The columns to return",
+            "columns.0: string: The columns to return",
             "filter: string: The filter to apply, optional, defaults to None",
             "limit: integer: The limit to apply, optional, defaults to 5"
         ],
-        "managedParamsSchemaDescription": {},
+        "managedParamsSchemaDescription": {
+            "warehouse": {
+                "type": "Secret",
+                "description": "Your Snowflake virtual warehouse to use for queries"
+            },
+            "database": {
+                "type": "Secret",
+                "description": "Your Snowflake database to use for queries"
+            },
+            "schema": {
+                "type": "Secret",
+                "description": "Your Snowflake schema to use for queries"
+            },
+            "service": {
+                "type": "Secret",
+                "description": "The name of the Cortex Search service to use"
+            }
+        },
         "inputFileVersion": "v3",
         "kind": "action",
-        "actionSignature": "action/args: 'query: str, warehouse: str, database: str, schema: str, service: str, columns: list | None=None, filter: dict | None=None, limit: int=5'"
+        "actionSignature": "action/args: 'query: str, warehouse: Secret, database: Secret, schema: Secret, service: Secret, columns: list, filter: dict | None=None, limit: int=5'"
     }
 }

--- a/agents/cortex-search-example/actions/Sema4.ai/snowflake-cortex/package.yaml
+++ b/agents/cortex-search-example/actions/Sema4.ai/snowflake-cortex/package.yaml
@@ -5,7 +5,7 @@ name: Snowflake Cortex
 description: Snowflake Cortex AI Actions
 
 # Package version number, recommend using semver.org
-version: 1.0.0
+version: 1.0.1
 
 spec-version: v2
 
@@ -21,10 +21,10 @@ dependencies:
   - tabulate=0.9.0
   - PyYAML=6.0.2
   - openpyxl=3.2.0b1
-  - snowflake=1.0.4
-  - snowflake-snowpark-python=1.27.0
+  - snowflake=1.0.5
+  - snowflake-snowpark-python=1.28.0
   - pyjwt=2.10.1
-  - streamlit=1.42.0
+  - streamlit=1.42.2
 
 packaging:
   # By default, all files and folders in this directory are packaged when uploaded.

--- a/agents/cortex-search-example/actions/Sema4.ai/snowflake-cortex/snowflake_actions.py
+++ b/agents/cortex-search-example/actions/Sema4.ai/snowflake-cortex/snowflake_actions.py
@@ -1,13 +1,12 @@
-from sema4ai.actions import Response, action
-
+from sema4ai.actions import Response, action, Secret
 from utils import execute_query
 
 @action
 def snowflake_execute_query(
     query: str,
-    warehouse: str = "",
-    database: str = None,
-    schema: str = None,
+    warehouse: Secret,
+    database: Secret,
+    schema: Secret,
     numeric_args: list = None,
 ) -> Response[list]:
     """
@@ -15,9 +14,9 @@ def snowflake_execute_query(
 
     Args:
         query: The query to execute.
-        database: The database to use.
-        schema: The schema to use.
-        warehouse: The warehouse to use.
+        database: Your Snowflake database to use for queries.
+        schema: Your Snowflake schema to use for queries.
+        warehouse: Your Snowflake virtual warehouse to use for queries.
         numeric_args: A list of numeric arguments to pass to the query.
 
     Returns:
@@ -26,7 +25,7 @@ def snowflake_execute_query(
 
     return Response(result=execute_query(
                 query=query,
-                warehouse=warehouse,
-                database=database,
-                schema=schema,
+                warehouse=warehouse.value,
+                database=database.value,
+                schema=schema.value,
                 numeric_args=numeric_args))

--- a/agents/cortex-search-example/actions/Sema4.ai/snowflake-cortex/utils.py
+++ b/agents/cortex-search-example/actions/Sema4.ai/snowflake-cortex/utils.py
@@ -1,13 +1,9 @@
-from contextlib import closing, contextmanager
-
-import snowflake.connector
-from sema4ai.data import get_snowflake_connection_details
 import os
-import json
-from datetime import datetime
 import pandas as pd
+import snowflake.connector
 from pathlib import Path
-
+from contextlib import closing, contextmanager
+from sema4ai.data import get_snowflake_connection_details
 
 def _get_snowflake_connection(
     role: str = None,

--- a/agents/cortex-search-example/agent-spec.yaml
+++ b/agents/cortex-search-example/agent-spec.yaml
@@ -6,7 +6,7 @@ agent-package:
     model:
       provider: OpenAI
       name: gpt-4o
-    version: 0.0.1
+    version: 0.0.2
     architecture: agent
     reasoning: disabled
     runbook: runbook.md

--- a/agents/cortex-search-example/agent-spec.yaml
+++ b/agents/cortex-search-example/agent-spec.yaml
@@ -14,7 +14,7 @@ agent-package:
     - name: Snowflake Cortex
       organization: Sema4.ai
       type: folder
-      version: 1.0.0
+      version: 1.0.1
       whitelist: cortex_search,cortex_get_search_specification
       path: Sema4.ai/snowflake-cortex
     knowledge: []

--- a/agents/cortex-search-example/runbook.md
+++ b/agents/cortex-search-example/runbook.md
@@ -8,17 +8,6 @@ To help you with the analysis, you have Cortex Search at your disposal. Here's h
 - Use Cortex Search to search for data relevant to the user's request.
 - Do not use any other tools or services to perform the knowledge search.
 
-## Configuration
-These parameters are used to configure and execute search operations within your Snowflake environment. They specify where to look for data and which search service to use.
-
-### Cortex Search
-The Search Service specifies which search index to use for executing search operations. It's crucial for Cortex Search to know where to look for relevant data. *Replace the following with the right values for your environment.*
-
-Warehouse: COMPUTE_WH
-Database: CORTEX_SEARCH_TUTORIAL_DB
-Schema: PUBLIC
-Service Name: AIRBNB_SVC
-
 ## Steps
 1. **Understand the User's Request:** 
 - Listen carefully to the user's question or request for analysis.


### PR DESCRIPTION
## Description

Updated to cortex actions 1.0.1 where the configurations are now secrets, instead of being in the Runbook.

## How can (was) this tested?

My local Studio

## Screenshots (if needed)

## Checklist:

- [X] I have bumped the version number for the Action Package / Agent
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation - README.md file
- [X] I have updated the CHANGELOG.md file in correspondence with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
