### PR TITLE
Fix Excel 365 `update range` action with llm

### DIFF
--- a/actions/microsoft-excel/CHANGELOG.md
+++ b/actions/microsoft-excel/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.0.0] - 2025-02-26
+
+### Changed
+
+- Dropped `_action` from action names.
+
+### Fixed
+
+- Modified how `operation` parameter is defined for `update_range` action.
+  This was problematic for LLM tool calling.
+
 ## [1.0.2] - 2025-01-09
 
 ### Changed

--- a/actions/microsoft-excel/microsoft_excel/add_worksheet_action.py
+++ b/actions/microsoft-excel/microsoft_excel/add_worksheet_action.py
@@ -6,7 +6,7 @@ from microsoft_excel._client import Client, create_worksheet, get_client  # noqa
 
 
 @action(is_consequential=True)
-def add_sheet_action(
+def add_sheet(
     token: OAuth2Secret[
         Literal["microsoft"],
         list[Literal["Files.ReadWrite"]],

--- a/actions/microsoft-excel/microsoft_excel/create_workbook_action.py
+++ b/actions/microsoft-excel/microsoft_excel/create_workbook_action.py
@@ -7,7 +7,7 @@ from microsoft_excel.models.workbook import Workbook
 
 
 @action(is_consequential=True)
-def create_workbook_action(
+def create_workbook(
     workbook_name: str,
     token: OAuth2Secret[
         Literal["microsoft"],

--- a/actions/microsoft-excel/microsoft_excel/get_worksheet_action.py
+++ b/actions/microsoft-excel/microsoft_excel/get_worksheet_action.py
@@ -7,7 +7,7 @@ from microsoft_excel.models.worksheet import Range, Worksheet, WorksheetInfo
 
 
 @action(is_consequential=False)
-def get_worksheet_action(
+def get_worksheet(
     workbook_id: str,
     worksheet_id_or_name: str,
     token: OAuth2Secret[

--- a/actions/microsoft-excel/microsoft_excel/update_range_action.py
+++ b/actions/microsoft-excel/microsoft_excel/update_range_action.py
@@ -85,7 +85,13 @@ class UpdateRange(BaseModel):
         ),
     ]
     start_cell: Annotated[str, Field(pattern=_ADDRESS_PATTERN)]
-    operation: Literal["replace", "insert_shift_right", "insert_shift_down"]
+    operation: Annotated[
+        str,
+        Field(
+            description="The operation to be performed on the range. "
+            "Possible values: 'replace', 'insert_shift_right', 'insert_shift_down'."
+        ),
+    ]
 
     @field_validator("values", mode="after")
     @classmethod
@@ -129,7 +135,7 @@ class _RangeResponse(BaseModel, extra="ignore"):
 
 
 @action(is_consequential=True)
-def update_range_action(
+def update_range(
     workbook_id: str,
     worksheet_id_or_name: str,
     data: UpdateRange,

--- a/actions/microsoft-excel/package.yaml
+++ b/actions/microsoft-excel/package.yaml
@@ -1,5 +1,5 @@
 # Required: A short name for the action package
-name: ZMicrosoft 365 Excel
+name: Microsoft 365 Excel
 
 # Required: A description of what's in the action package.
 description: Actions for manipulating Microsoft 365 Excel files.

--- a/actions/microsoft-excel/package.yaml
+++ b/actions/microsoft-excel/package.yaml
@@ -1,11 +1,11 @@
 # Required: A short name for the action package
-name: Microsoft 365 Excel
+name: ZMicrosoft 365 Excel
 
 # Required: A description of what's in the action package.
 description: Actions for manipulating Microsoft 365 Excel files.
 
 # Package version number, recommend using semver.org
-version: 1.0.2
+version: 2.0.0
 
 # The version of the `package.yaml` format.
 spec-version: v2


### PR DESCRIPTION
## Description

LLM fails to call the action `update_range` with correct schema (thus the actual action is never called).
Value for `operation` parameter was given a value, which is not supported by the action definition.
Modified how `operation` is defined for the action.

The `_action` postfix has been removed from the action names.

## How can (was) this tested?

Replicated the issue with Studio 1.2.0-alpha11 using OpenAI GTP-4o model. 
A fix was tested using the same.

## Screenshots (if needed)

## Checklist:

- [x] I have bumped the version number for the Action Package / Agent
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - README.md file
- [x] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
