### PR TITLE
Fix issue caused by action renaming

### DIFF
--- a/actions/microsoft-excel/CHANGELOG.md
+++ b/actions/microsoft-excel/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.0.1] - 2025-02-27
+
+### Fixed
+
+- Fix `create_workbook` action.
+
 ## [2.0.0] - 2025-02-26
 
 ### Changed

--- a/actions/microsoft-excel/microsoft_excel/_client.py
+++ b/actions/microsoft-excel/microsoft_excel/_client.py
@@ -75,7 +75,7 @@ def get_client(token: OAuth2Secret) -> Client:
         client.close()
 
 
-def create_workbook(client: Client, workbook_name: str) -> Workbook:
+def _create_workbook(client: Client, workbook_name: str) -> Workbook:
     output = BytesIO()
     workbook_name = f"{workbook_name}.xlsx"
     with xlsxwriter.Workbook(output, {"in_memory": True}) as local_workbook:
@@ -92,7 +92,7 @@ def create_workbook(client: Client, workbook_name: str) -> Workbook:
     return workbook
 
 
-def create_worksheet(
+def _create_worksheet(
     client: Client, *, workbook_id: str, worksheet_name: str | None = None
 ) -> WorksheetInfo:
     if worksheet_name and worksheet_name.strip():
@@ -107,7 +107,7 @@ def create_worksheet(
     )
 
 
-def load_worksheets_for_workbook(client: Client, workbook: Workbook) -> Workbook:
+def _load_worksheets_for_workbook(client: Client, workbook: Workbook) -> Workbook:
     if workbook.worksheets is None:
         worksheet_info = client.get(
             APIResponse[WorksheetInfo],

--- a/actions/microsoft-excel/microsoft_excel/add_worksheet_action.py
+++ b/actions/microsoft-excel/microsoft_excel/add_worksheet_action.py
@@ -2,7 +2,7 @@ from typing import Literal
 
 from sema4ai.actions import OAuth2Secret, Response, action
 
-from microsoft_excel._client import Client, create_worksheet, get_client  # noqa: F401
+from microsoft_excel._client import Client, _create_worksheet, get_client  # noqa: F401
 
 
 @action(is_consequential=True)
@@ -27,7 +27,7 @@ def add_sheet(
 
     with get_client(token) as client:  # type: Client
         return Response(
-            result=create_worksheet(
+            result=_create_worksheet(
                 client, workbook_id=workbook_id, worksheet_name=worksheet_name
             )
         )

--- a/actions/microsoft-excel/microsoft_excel/create_workbook_action.py
+++ b/actions/microsoft-excel/microsoft_excel/create_workbook_action.py
@@ -2,7 +2,7 @@ from typing import Literal
 
 from sema4ai.actions import OAuth2Secret, Response, action
 
-from microsoft_excel._client import Client, create_workbook, get_client  # noqa: F401
+from microsoft_excel._client import Client, _create_workbook, get_client  # noqa: F401
 from microsoft_excel.models.workbook import Workbook
 
 
@@ -24,4 +24,4 @@ def create_workbook(
     """
 
     with get_client(token) as client:  # type: Client
-        return Response(result=create_workbook(client, workbook_name))
+        return Response(result=_create_workbook(client, workbook_name))

--- a/actions/microsoft-excel/microsoft_excel/get_workbook_action.py
+++ b/actions/microsoft-excel/microsoft_excel/get_workbook_action.py
@@ -6,7 +6,7 @@ from sema4ai.actions import ActionError, OAuth2Secret, Response, action
 from microsoft_excel._client import (  # noqa: F401
     Client,
     get_client,
-    load_worksheets_for_workbook,
+    _load_worksheets_for_workbook,
 )
 from microsoft_excel._constants import EXCEL_MIME_TYPE, FILE_EXTENSION
 from microsoft_excel.models import APIResponse
@@ -31,7 +31,7 @@ class _Item(BaseModel, extra="ignore"):
 
     def as_workbook(self, client: Client) -> Workbook:
         workbook = Workbook(id=self.id, name=self.name, web_url=self.web_url)
-        return load_worksheets_for_workbook(client, workbook)
+        return _load_worksheets_for_workbook(client, workbook)
 
 
 _SearchResponse = APIResponse[OnErrorOmit[_Item]]

--- a/actions/microsoft-excel/microsoft_excel/update_range_action.py
+++ b/actions/microsoft-excel/microsoft_excel/update_range_action.py
@@ -77,6 +77,12 @@ def convert_column_number_to_label(value: int) -> str:
     return column_address
 
 
+def _convert_value_to_string(value: any) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
 class UpdateRange(BaseModel):
     values: Annotated[
         Values,
@@ -102,7 +108,8 @@ class UpdateRange(BaseModel):
                 "values must have the shape of a matrix, where each row has the same number of elements"
             )
 
-        return values
+        # Convert all values to strings
+        return [[_convert_value_to_string(cell) for cell in row] for row in values]
 
     @property
     def address(self) -> str:

--- a/actions/microsoft-excel/package.yaml
+++ b/actions/microsoft-excel/package.yaml
@@ -5,7 +5,7 @@ name: Microsoft 365 Excel
 description: Actions for manipulating Microsoft 365 Excel files.
 
 # Package version number, recommend using semver.org
-version: 2.0.0
+version: 2.0.1
 
 # The version of the `package.yaml` format.
 spec-version: v2
@@ -15,7 +15,7 @@ dependencies:
   - python=3.10.16
   - uv=0.4.17
   pypi:
-  - sema4ai-actions=1.3.0
+  - sema4ai-actions=1.3.5
   - pydantic=2.10.4
   - httpx=0.27.0
   - XlsxWriter=3.2.0


### PR DESCRIPTION
## Description

Action renaming in version 2.0.0 broke action `create_workbook`.

## How can (was) this tested?

Tested in Studio 1.20-alpha11

## Screenshots (if needed)

## Checklist:

- [x] I have bumped the version number for the Action Package / Agent
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - README.md file
- [x] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
