### PR TITLE
drop vitality actions

### DIFF
--- a/bin/publisher/whitelist.json
+++ b/bin/publisher/whitelist.json
@@ -34,9 +34,7 @@
             "perplexity"
         ],
         "agents": [
-            "wayback-machine-agent",
-            "sales-contact-finder",
-            "similar-company-finder"
+            "wayback-machine-agent"
         ]
     },
     "spcs": {

--- a/bin/publisher/whitelist.json
+++ b/bin/publisher/whitelist.json
@@ -25,9 +25,6 @@
             "salesforce",
             "servicenow",
             "slack",
-            "vitality-lab-results",
-            "vitality-medications",
-            "vitality-workouts",
             "wayback-machine",
             "youtube",
             "zendesk",
@@ -37,7 +34,9 @@
             "perplexity"
         ],
         "agents": [
-            "wayback-machine-agent"
+            "wayback-machine-agent",
+            "sales-contact-finder",
+            "similar-company-finder"
         ]
     },
     "spcs": {


### PR DESCRIPTION
## Description

Dropped from standard whitelist:
- Actions: "vitality-lab-results", "vitality-medications", "vitality-workouts", 
- 
## How can (was) this tested?

## Screenshots (if needed)

## Checklist:

- [ ] I have bumped the version number for the Action Package / Agent
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - README.md file
- [ ] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
