### PR TITLE
Added support for searching projects

### DIFF
--- a/actions/linear/CHANGELOG.md
+++ b/actions/linear/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - 2025-03-07
+
+### Added
+
+- New `search_projects` action to search Linear projects
+- Support for filtering projects by name, team, and initiative
+- New models for project filtering and responses (`ProjectFilterOptions`, `Project`, `ProjectList`)
+- Input validation for empty string handling in project filters
+- Dependency versions updated
+
 ## [1.0.2] - 2025-03-06
 
 ### Changed

--- a/actions/linear/devdata/input_search_projects.json
+++ b/actions/linear/devdata/input_search_projects.json
@@ -1,0 +1,89 @@
+{
+    "inputs": [
+        {
+            "inputName": "Search by name",
+            "inputValue": {
+                "filter_options": {
+                    "name": "Leverage Existing RPA",
+                    "team_name": "",
+                    "initiative": "",
+                    "limit": "",
+                    "ordering": ""
+                },
+                "api_key": ""
+            }
+        },
+        {
+            "inputName": "Search by team",
+            "inputValue": {
+                "filter_options": {
+                    "name": "",
+                    "team_name": "Work Room",
+                    "initiative": "",
+                    "limit": "",
+                    "ordering": ""
+                },
+                "api_key": ""
+            }
+        },
+        {
+            "inputName": "Search by initiative",
+            "inputValue": {
+                "filter_options": {
+                    "name": "",
+                    "team_name": "",
+                    "initiative": "Sai",
+                    "limit": "",
+                    "ordering": ""
+                },
+                "api_key": ""
+            }
+        },
+        {
+            "inputName": "Search with multiple filters",
+            "inputValue": {
+                "filter_options": {
+                    "name": "",
+                    "team_name": "Studio",
+                    "initiative": "Sai",
+                    "limit": "10",
+                    "ordering": "createdAt"
+                },
+                "api_key": ""
+            }
+        },
+        {
+            "inputName": "Get recent projects",
+            "inputValue": {
+                "filter_options": {
+                    "name": "",
+                    "team_name": "",
+                    "initiative": "",
+                    "limit": "5",
+                    "ordering": "updatedAt"
+                },
+                "api_key": ""
+            }
+        }
+    ],
+    "metadata": {
+        "actionName": "search_projects",
+        "actionRelativePath": "actions.py",
+        "schemaDescription": [
+            "filter_options.name: string",
+            "filter_options.team_name: string",
+            "filter_options.initiative: string",
+            "filter_options.limit: string",
+            "filter_options.ordering: string"
+        ],
+        "managedParamsSchemaDescription": {
+            "api_key": {
+                "type": "Secret",
+                "description": "The API key to use to authenticate with the Linear API."
+            }
+        },
+        "inputFileVersion": "v3",
+        "kind": "action",
+        "actionSignature": "action/args: 'filter_options: ProjectFilterOptions, api_key: Secret'"
+    }
+}

--- a/actions/linear/package.yaml
+++ b/actions/linear/package.yaml
@@ -5,7 +5,7 @@ name: Linear
 description: Linear actions for handling issues
 
 # Package version number, recommend using semver.org
-version: 1.0.2
+version: 1.1.0
 
 # The version of the `package.yaml` format.
 spec-version: v2
@@ -16,8 +16,8 @@ dependencies:
     - python-dotenv=1.0.1
     - uv=0.4.17
   pypi:
-    - sema4ai-actions=1.3.5
-    - pydantic=2.10.4
+    - sema4ai-actions=1.3.6
+    - pydantic=2.10.6
     - requests=2.32.3
 
 packaging:

--- a/actions/linear/queries.py
+++ b/actions/linear/queries.py
@@ -201,3 +201,32 @@ query WorkflowStates($teamId: String!) {
     }
 }
 """
+
+query_search_projects = """
+query SearchProjects($filter: ProjectFilter, $orderBy: PaginationOrderBy, $first: Int = 50) {
+    projects(filter: $filter, orderBy: $orderBy, first: $first) {
+        nodes {
+            id
+            name
+            description
+            startDate
+            targetDate
+            teams {
+                nodes {
+                    id
+                    name
+                }
+            }
+            initiatives {
+                nodes {
+                    id
+                    name
+                }
+            }
+            url
+            createdAt
+            updatedAt
+        }
+    }
+}
+"""


### PR DESCRIPTION
## Description

Added a new `search_projects` action to the Linear Action Package that enables searching for projects by name, team, and initiative. This feature enhances the package's capabilities by providing project management functionality alongside the existing issue management features.

Key additions include:
- New `search_projects` action with filtering capabilities
- Project-related models for type safety and validation
- Proper handling of empty string inputs
- Post-query filtering for team names due to Linear API limitations

## How can (was) this tested?

The following test scenarios were implemented:

- [x] Search projects by name
- [x] Search projects by team name (post-query filtering)
- [x] Search projects by initiative
- [x] Test empty string handling in filter options
- [x] Test pagination limits
- [x] Test ordering (createdAt, updatedAt)

Test using the example inputs in `devdata/input_search_projects.json` with different combinations of:
- Project name filters
- Team name filters
- Initiative filters
- Result limits
- Ordering options+

## Screenshots (if needed)

N/A

## Checklist:

- [x] I have bumped the version number for the Action Package / Agent (1.1.0)
- [x] I have performed a self-review of my own code
- [x] I have updated the CHANGELOG.md file in correspondence with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
