### PR TITLE
Separate SPCS actions into a different manifest file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 *.zip
 manifest.json
 published_manifest.json
+published_manifest_sai.json
 published_agents_manifest.json
 **/.DS_STORE
 !runbooks/manifest.json

--- a/bin/publisher/build_all_packages.py
+++ b/bin/publisher/build_all_packages.py
@@ -44,6 +44,9 @@ def build_all_packages():
     save_manifest(
         sai_manifest, os.path.join(gallery_actions_folder, "manifest_sai.json"), whitelist["standard"]["actions"]
     )
+    save_manifest(
+        sai_manifest, os.path.join(gallery_actions_folder, "manifest_sai_spcs.json"), whitelist["spcs"]["actions"]
+    )
 
     print(f"\n\n-> Gallery generated in: {gallery_actions_folder}")
 

--- a/bin/publisher/build_updated_packages.py
+++ b/bin/publisher/build_updated_packages.py
@@ -123,6 +123,12 @@ def build_updated_packages():
         whitelist["spcs"]["actions"],
     )
 
+    save_manifest(
+        new_manifest_sai,
+        os.path.join(gallery_actions_folder, "manifest_sai_spcs.json"),
+        whitelist["spcs"]["actions"],
+    )
+
 
 if __name__ == "__main__":
     build_updated_packages()


### PR DESCRIPTION
## Description

Separate SPCS actions into a different manifest file

## How can (was) this tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.

Please also list any relevant details for your test configuration:

- [ ] Test A
- [ ] Test B

## Screenshots (if needed)

## Checklist:

- [ ] I have bumped the version number for the Action Package / Agent
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - README.md file
- [ ] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
