### PR TITLE
Fixed issue where database and schema fail when lowercase

### DIFF
--- a/actions/snowflake-cortex-analyst/CHANGELOG.md
+++ b/actions/snowflake-cortex-analyst/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.1] - 2025-04-02
+
+- Updated warehouse, database and schema to be used in the query to be uppercase fixing the issue when secrets are lowercase.
+
 ## [1.0.0] - 2025-03-23
 
 - This package is splitted from the Snowflake Cortex package and only contains actions to send messages to the Cortex Analyst and execute queries.

--- a/actions/snowflake-cortex-analyst/package.yaml
+++ b/actions/snowflake-cortex-analyst/package.yaml
@@ -5,7 +5,7 @@ name: Snowflake Cortex Analyst
 description: Snowflake Cortex reliably answers business questions based on your structured data in Snowflake.
 
 # Package version number, recommend using semver.org
-version: 1.0.0
+version: 1.0.1
 
 spec-version: v2
 
@@ -18,7 +18,7 @@ dependencies:
   - sema4ai-data=1.0.2
   - snowflake-connector-python[pandas]=3.14.0
   - pandas=2.2.3
-  - snowflake=1.1.0
+  - snowflake=1.2.0
   - pyjwt=2.10.1
 
 packaging:

--- a/actions/snowflake-cortex-analyst/utils.py
+++ b/actions/snowflake-cortex-analyst/utils.py
@@ -67,11 +67,11 @@ def execute_query(
         conn.cursor()
     ) as cursor:
         if warehouse:
-            cursor.execute(f'USE WAREHOUSE "{warehouse}"')
+            cursor.execute(f'USE WAREHOUSE "{warehouse.upper()}"')
         if database:
-            cursor.execute(f'USE DATABASE "{database}"')
+            cursor.execute(f'USE DATABASE "{database.upper()}"')
         if schema:
-            cursor.execute(f'USE SCHEMA "{schema}"')
+            cursor.execute(f'USE SCHEMA "{schema.upper()}"')
 
         cursor.execute(query, numeric_args)
 


### PR DESCRIPTION
## Description

Snowflake team reported that the execute query fails when database and schema (secrets) are written lowercase. This is fixed by forcing them uppercase when used in the execute_query.

## How can (was) this tested?

Tested locally in Cursor and in Studio.

## Checklist:

- [X] I have bumped the version number for the Action Package / Agent
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation - README.md file
- [X] I have updated the CHANGELOG.md file in correspondence with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
