### PR TITLE
Updated docstrings of Cortex Search to allow agent to use filters better

### DIFF
--- a/actions/snowflake-cortex-search/CHANGELOG.md
+++ b/actions/snowflake-cortex-search/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.3] - 2025-04-29
+
+### Changed
+
+- Updated the search query docstrings so that agent will be better able to use the filter parameter.
+- Updated the default limit to 10 to match the Snowflake Cortex Search API default.
+- Dependency versions updated
+
 ## [1.0.2] - 2025-04-04
 
 ### Changed

--- a/actions/snowflake-cortex-search/cortex_actions.py
+++ b/actions/snowflake-cortex-search/cortex_actions.py
@@ -50,20 +50,31 @@ def cortex_search(
     service: Secret,
     columns: list | None = None,
     filter: dict | None = None,
-    limit: int = 5,
+    limit: int = 10,
 ) -> Response[list]:
     """
     Queries the cortex search service in the session state and returns a list of results.
 
     Args:
-        query: The query to execute
+        query: The full-text search query to find relevant content. This is for semantic search only 
+               and should NOT contain filter conditions. Example: "customer feedback about returns"
         warehouse: Your Snowflake virtual warehouse to use for queries
         database: Your Snowflake database to use for queries
         schema: Your Snowflake schema to use for queries
         service: The name of the Cortex Search service to use
-        columns: The columns to return
-        filter: The filter to apply, optional, defaults to None
-        limit: The limit to apply, optional, defaults to 5
+        columns: The columns to return. These columns must be based on the columns returned by cortex_get_search_specification.
+        filter: Dictionary specifying filter conditions using Snowflake Cortex Search syntax. Only use columns that are part of the attribute_columns returned by cortex_get_search_specification.
+            Must use specific operators:
+            - "@eq": Equality filter. Example: {"@eq": {"COLUMN_NAME": "value"}}
+            - "@contains": Array contains filter. Example: {"@contains": {"ARRAY_COLUMN": "value"}}
+            - "@gte": Greater than or equal. Example: {"@gte": {"NUMERIC_COLUMN": 10}}
+            - "@lte": Less than or equal. Example: {"@lte": {"NUMERIC_COLUMN": 100}}
+            
+            Logical operators can combine conditions:
+            - "@and": Example: {"@and": [{"@eq": {"COL1": "val1"}}, {"@eq": {"COL2": "val2"}}]}
+            - "@or": Example: {"@or": [{"@eq": {"COL1": "val1"}}, {"@eq": {"COL1": "val2"}}]}
+            - "@not": Example: {"@not": {"@eq": {"COL1": "val1"}}}
+        limit: The limit to apply, optional, defaults to 10
 
     Returns:
         The results of the query.

--- a/actions/snowflake-cortex-search/devdata/input_cortex_get_search_specification.json
+++ b/actions/snowflake-cortex-search/devdata/input_cortex_get_search_specification.json
@@ -4,18 +4,18 @@
             "inputName": "input-uppercase",
             "inputValue": {
                 "warehouse": "COMPUTE_WH",
-                "database": "CORTEX_SEARCH_TUTORIAL_DB",
+                "database": "CALL_CENTER_DATA",
                 "schema": "PUBLIC",
-                "service": "AIRBNB_SVC"
+                "service": "CALL_LOGS"
             }
         },
         {
             "inputName": "input-lowercase",
             "inputValue": {
                 "warehouse": "compute_wh",
-                "database": "cortex_search_tutorial_db",
+                "database": "call_center_data",
                 "schema": "public",
-                "service": "airbnb_svc"
+                "service": "call_logs"
             }
         }
     ],

--- a/actions/snowflake-cortex-search/devdata/input_cortex_search.json
+++ b/actions/snowflake-cortex-search/devdata/input_cortex_search.json
@@ -3,31 +3,52 @@
         {
             "inputName": "input-uppercase",
             "inputValue": {
-                "query": "Can you analyze the different types of cancellation policies by room type?",
+                "query": "What were the opening lines of the call by the agent?",
                 "columns": [
-                    "room_type",
-                    "cancellation_policy"
+                    "CALL_ID",
+                    "TRANSCRIPT_TEXT"
                 ],
                 "limit": 10,
                 "warehouse": "COMPUTE_WH",
-                "database": "CORTEX_SEARCH_TUTORIAL_DB",
+                "database": "CALL_CENTER_DATA",
                 "schema": "PUBLIC",
-                "service": "AIRBNB_SVC"
+                "service": "CALL_LOGS"
+            }
+        },
+        {
+            "inputName": "input-with-filter",
+            "inputValue": {
+                "query": "What were the opening lines of the call by the agent?",
+                "columns": [
+                    "CALL_ID",
+                    "TRANSCRIPT_TEXT"
+                ],
+                "limit": 10,
+                "filter": {
+                    "@or": [
+                        { "@eq": { "CALL_ID": "CALL_776" } },
+                        { "@eq": { "CALL_ID": "CALL_51" } }
+                    ]
+                },
+                "warehouse": "COMPUTE_WH",
+                "database": "CALL_CENTER_DATA",
+                "schema": "PUBLIC",
+                "service": "CALL_LOGS"
             }
         },
         {
             "inputName": "input-lowercase",
             "inputValue": {
-                "query": "Can you analyze the different types of cancellation policies by room type?",
+                "query": "What were the opening lines of the call by the agent?",
                 "columns": [
-                    "room_type",
-                    "cancellation_policy"
+                    "call_id",
+                    "transcript_text"
                 ],
                 "limit": 10,
                 "warehouse": "compute_wh",
-                "database": "cortex_search_tutorial_db",
+                "database": "call_center_data",
                 "schema": "public",
-                "service": "airbnb_svc"
+                "service": "call_logs"
             }
         }
     ],
@@ -35,10 +56,10 @@
         "actionName": "cortex_search",
         "actionRelativePath": "cortex_actions.py",
         "schemaDescription": [
-            "query: string: The query to execute",
-            "columns: string: The columns to return",
-            "filter: string: The filter to apply, optional, defaults to None",
-            "limit: integer: The limit to apply, optional, defaults to 5"
+            "query: string: Your search query, to search over the text column in the service.",
+            "columns: string: The columns to return. These columns must be based on the columns returned by cortex_get_search_specification.",
+            "filter: string: Dictionary specifying filter conditions using Snowflake Cortex Search syntax. Only use columns that are part of the attribute_columns returned by cortex_get_search_specification.\nMust use specific operators:\n- \"@eq\": Equality filter. Example: {\"@eq\": {\"COLUMN_NAME\": \"value\"}}\n- \"@contains\": Array contains filter. Example: {\"@contains\": {\"ARRAY_COLUMN\": \"value\"}}\n- \"@gte\": Greater than or equal. Example: {\"@gte\": {\"NUMERIC_COLUMN\": 10}}\n- \"@lte\": Less than or equal. Example: {\"@lte\": {\"NUMERIC_COLUMN\": 100}}\n\nLogical operators can combine conditions:\n- \"@and\": Example: {\"@and\": [{\"@eq\": {\"COL1\": \"val1\"}}, {\"@eq\": {\"COL2\": \"val2\"}}]}\n- \"@or\": Example: {\"@or\": [{\"@eq\": {\"COL1\": \"val1\"}}, {\"@eq\": {\"COL1\": \"val2\"}}]}\n- \"@not\": Example: {\"@not\": {\"@eq\": {\"COL1\": \"val1\"}}}",
+            "limit: integer: The limit to apply, optional, defaults to 10"
         ],
         "managedParamsSchemaDescription": {
             "warehouse": {
@@ -60,6 +81,6 @@
         },
         "inputFileVersion": "v3",
         "kind": "action",
-        "actionSignature": "action/args: 'query: str, warehouse: Secret, database: Secret, schema: Secret, service: Secret, columns: list | None=None, filter: dict | None=None, limit: int=5'"
+        "actionSignature": "action/args: 'query: str, warehouse: Secret, database: Secret, schema: Secret, service: Secret, columns: list | None=None, filter: dict | None=None, limit: int=10'"
     }
 }

--- a/actions/snowflake-cortex-search/package.yaml
+++ b/actions/snowflake-cortex-search/package.yaml
@@ -5,7 +5,7 @@ name: Snowflake Cortex Search
 description: Cortex Search is a retrieval engine that provides agent the context it needs based on your latest data.
 
 # Package version number, recommend using semver.org
-version: 1.0.2
+version: 1.0.3
 
 spec-version: v2
 
@@ -14,11 +14,11 @@ dependencies:
     - python=3.11.11
     - uv=0.6.11
   pypi:
-    - sema4ai-actions=1.3.8
-    - sema4ai-data=1.0.2
-    - snowflake-connector-python[pandas]=3.14.0
+    - sema4ai-actions=1.3.11
+    - sema4ai-data=1.0.3
+    - snowflake-connector-python[pandas]=3.15.0
     - pandas=2.2.3
-    - snowflake=1.2.0
+    - snowflake=1.4.0
     - pyjwt=2.10.1
 
 packaging:


### PR DESCRIPTION
## Description

I realized that agents were not able to use the filters parameter of cortex search, but instead was trying to put all details in the "query" - leading to errors.

Updated the docstring to contain more specific instructions.

## How can (was) this tested?

Tested in Studio with a test agent that was failing before. Works now.

## Checklist:

- [X] I have bumped the version number for the Action Package / Agent
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation - README.md file
- [X] I have updated the CHANGELOG.md file in correspondence with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
