### PR TITLE
Update env variable name for API discovery

### DIFF
--- a/actions/agent-connector/CHANGELOG.md
+++ b/actions/agent-connector/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [4.0.1] - 2025-05-05
+
+### Changed
+
+- Updated to work with Agent Compute 1.2.2 which has a environment variable for the API URL. NOTE: Use previous version of the action if you are using Agent Compute 1.2.1 or earlier.
+
 ## [4.0.0] - 2025-05-03
 
 **Breaking changes as this aciont package is modified to use the public Agent API.**

--- a/actions/agent-connector/agent_api_client.py
+++ b/actions/agent-connector/agent_api_client.py
@@ -53,9 +53,7 @@ class AgentAPIClient:
                 return False
 
         # First check environment variable
-        if url := os.getenv("SEMA4AI_TENANT_URL"):
-            # Append /api/v1 to the base URL for cloud environments
-            api_url = f"{url}/api/v1"
+        if api_url := os.getenv("SEMA4AI_API_V1_URL"):
             if test_url(api_url):
                 return api_url
 

--- a/actions/agent-connector/package.yaml
+++ b/actions/agent-connector/package.yaml
@@ -5,7 +5,7 @@ name: Agent Connector
 description: Actions to connect agents with each other
 
 # Package version number, recommend using semver.org
-version: 4.0.0
+version: 4.0.1
 
 # The version of the `package.yaml` format.
 spec-version: v2


### PR DESCRIPTION
## Description

Changed to use the correct env variable name that ACE 1.2.2 exposes.

## How can (was) this tested?

In the above ACE version.

## Checklist:

- [X] I have bumped the version number for the Action Package / Agent
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation - README.md file
- [X] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
