### PR TITLE
Cortex Analyst: Updated to treat stage paths properly

### DIFF
--- a/actions/snowflake-cortex-analyst/CHANGELOG.md
+++ b/actions/snowflake-cortex-analyst/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.3] - 2025-05-20
+
+### Changed
+
+- Fixed the issue when the semantic model file path is copied from Snowsight and contains quotes and possibly whitespaces. These are now handled correctly.
+- Dependency versions updated
+
 ## [1.0.2] - 2025-04-04
 
 ### Changed

--- a/actions/snowflake-cortex-analyst/cortex_actions.py
+++ b/actions/snowflake-cortex-analyst/cortex_actions.py
@@ -17,12 +17,18 @@ def ask_cortex_analyst(semantic_model_file: Secret, message: str) -> Response[di
         The response from the Cortex Analyst.
     """
     with get_snowflake_connection() as conn:
+        # Clean the semantic_model_file value from potential extra quotes
+        clean_path = semantic_model_file.value
+        # Remove surrounding single quotes if present
+        if clean_path.startswith("'") and clean_path.endswith("'"):
+            clean_path = clean_path[1:-1]
+        
         request_body = {
             "timeout": 50000,
             "messages": [
                 {"role": "user", "content": [{"type": "text", "text": message}]}
             ],
-            "semantic_model_file": semantic_model_file.value,
+            "semantic_model_file": clean_path,
         }
 
         if is_running_in_spcs():

--- a/actions/snowflake-cortex-analyst/devdata/input_ask_cortex_analyst.json
+++ b/actions/snowflake-cortex-analyst/devdata/input_ask_cortex_analyst.json
@@ -1,10 +1,24 @@
 {
     "inputs": [
         {
-            "inputName": "input-1",
+            "inputName": "input-clean",
             "inputValue": {
                 "message": "Which regions are experiencing the fastest growth in sales in 2024?",
                 "semantic_model_file": "@CORTEX_ANALYST_DEMO.REVENUE_TIMESERIES.RAW_DATA/revenue_timeseries.yaml"
+            }
+        },
+        {
+            "inputName": "input-from-snowsight",
+            "inputValue": {
+                "message": "Which regions are experiencing the fastest growth in sales in 2024?",
+                "semantic_model_file": "'@\"CORTEX_ANALYST_DEMO\".\"REVENUE_TIMESERIES\".\"RAW_DATA\"/revenue_timeseries.yaml'"
+            }
+        },
+        {
+            "inputName": "input-spaces",
+            "inputValue": {
+                "message": "Which regions are experiencing the fastest growth in sales in 2024?",
+                "semantic_model_file": "'@\"CORTEX_ANALYST_DEMO\".\"REVENUE_TIMESERIES\".\"RAW_DATA\"/revenue timeseries.yaml'"
             }
         }
     ],

--- a/actions/snowflake-cortex-analyst/devdata/input_snowflake_execute_query.json
+++ b/actions/snowflake-cortex-analyst/devdata/input_snowflake_execute_query.json
@@ -7,7 +7,7 @@
                 "warehouse": "COMPUTE_WH",
                 "database": "CORTEX_ANALYST_DEMO",
                 "schema": "REVENUE_TIMESERIES",
-                "numeric_args": null
+                "numeric_args": []
             }
         }
     ],

--- a/actions/snowflake-cortex-analyst/package.yaml
+++ b/actions/snowflake-cortex-analyst/package.yaml
@@ -5,7 +5,7 @@ name: Snowflake Cortex Analyst
 description: Snowflake Cortex reliably answers business questions based on your structured data in Snowflake.
 
 # Package version number, recommend using semver.org
-version: 1.0.2
+version: 1.0.3
 
 spec-version: v2
 
@@ -14,11 +14,11 @@ dependencies:
     - python=3.11.11
     - uv=0.6.11
   pypi:
-    - sema4ai-actions=1.3.8
-    - sema4ai-data=1.0.2
-    - snowflake-connector-python[pandas]=3.14.0
+    - sema4ai-actions=1.3.11
+    - sema4ai-data=1.0.5
+    - snowflake-connector-python[pandas]=3.15.0
     - pandas=2.2.3
-    - snowflake=1.2.0
+    - snowflake=1.5.0
     - pyjwt=2.10.1
 
 packaging:


### PR DESCRIPTION
## Description

If user copies stage path for semantic model file from Snowsight, it contains quotes. That broke the ask cortex analyst action. Fixed to treat quotes and whitespaces properly.

## How can (was) this tested?

Tested locally in SDK with three scenarios, no quotes, quotes and whitespaces. Same in Studio.

## Checklist:

- [X] I have bumped the version number for the Action Package / Agent
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation - README.md file
- [X] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
