### PR TITLE
Add action to list tags for ZenDesk

### DIFF
--- a/actions/zendesk/CHANGELOG.md
+++ b/actions/zendesk/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.5.0] - 2025-05-22
+
+### Added
+
+- Add `Tags` datamodel
+- Add `TagsApi`
+- Add action `list_tags`
+
 ## [1.4.0] - 2025-05-08
 
 ### Added

--- a/actions/zendesk/README.md
+++ b/actions/zendesk/README.md
@@ -13,6 +13,7 @@ Possible actions with this package are:
 - list all available groups
 - create ticket
 - delete ticket
+- list top 100 tags
 
 ## Prompts
 

--- a/actions/zendesk/actions.py
+++ b/actions/zendesk/actions.py
@@ -2,11 +2,12 @@ from typing import Literal
 
 from sema4ai.actions import OAuth2Secret, Response, action
 
-from client import CommentsApi, GroupsApi, TicketsApi, UsersApi
+from client import CommentsApi, GroupsApi, TagsApi, TicketsApi, UsersApi
 from models import (
     AddComment,
     CommentsResponse,
     Group,
+    Tag,
     Ticket,
     TicketsResponse,
     UpdateTicket,
@@ -232,3 +233,26 @@ def delete_ticket(
     )
     client.delete(ticket_id)
     return Response(result=f"Ticket {ticket_id} deleted successfully")
+
+
+@action(is_consequential=False)
+def list_tags(
+    zendesk_credentials: OAuth2Secret[
+        Literal["zendesk"], list[Literal["read"]]
+    ],
+) -> Response[list[Tag]]:
+    """List top 100 used tags.
+
+    Args:
+        zendesk_credentials: Zendesk OAuth2 credentials
+
+    Returns:
+        List of tags.
+    """
+    client = TagsApi(
+        zendesk_credentials.access_token,
+        zendesk_credentials.metadata["server"],
+    )
+
+    response = client.list()
+    return Response(result=response)

--- a/actions/zendesk/actions.py
+++ b/actions/zendesk/actions.py
@@ -241,7 +241,7 @@ def list_tags(
         Literal["zendesk"], list[Literal["read"]]
     ],
 ) -> Response[list[Tag]]:
-    """List top 100 used tags.
+    """Lists up to 100 most popular tags in the last 60 days, in decreasing popularity.
 
     Args:
         zendesk_credentials: Zendesk OAuth2 credentials

--- a/actions/zendesk/client.py
+++ b/actions/zendesk/client.py
@@ -5,16 +5,18 @@ from time import sleep
 from typing import Any, Optional
 
 import sema4ai_http
+from sema4ai.actions import ActionError
+
 from models import (
     AddComment,
     CommentsResponse,
     Group,
+    Tag,
     Ticket,
     TicketsResponse,
     UpdateTicket,
     UsersResponse,
 )
-from sema4ai.actions import ActionError
 
 
 @dataclass
@@ -158,3 +160,10 @@ class GroupsApi(BaseApi):
         ).json()
 
         return [Group.model_validate(group) for group in response["groups"]]
+
+
+class TagsApi(BaseApi):
+    def list(self) -> list[Tag]:
+        response = self._call_api(sema4ai_http.get, "/api/v2/tags.json").json()
+
+        return [Tag.model_validate(tag) for tag in response["tags"]]

--- a/actions/zendesk/models.py
+++ b/actions/zendesk/models.py
@@ -269,6 +269,10 @@ class AddComment(BaseModel):
         return {"ticket": {"comment": self.model_dump(mode="json")}}
 
 
+class Tag(BaseModel):
+    name: Annotated[str, Field(description="The name of the tag")]
+
+
 class BaseResponse(BaseModel):
     @classmethod
     def from_response(cls, data: dict) -> Self:

--- a/actions/zendesk/models.py
+++ b/actions/zendesk/models.py
@@ -271,6 +271,9 @@ class AddComment(BaseModel):
 
 class Tag(BaseModel):
     name: Annotated[str, Field(description="The name of the tag")]
+    count: Annotated[
+        int, Field(description="The number of tickets with the tag")
+    ]
 
 
 class BaseResponse(BaseModel):

--- a/actions/zendesk/package.yaml
+++ b/actions/zendesk/package.yaml
@@ -5,7 +5,7 @@ name: Zendesk
 description: Operate Zendesk tickets, assignments and comments with Agents.
 
 # Package version number, recommend using semver.org
-version: 1.4.0
+version: 1.5.0
 
 # The version of the `package.yaml` format.
 spec-version: v2


### PR DESCRIPTION
## Description

Add action to list most used tags from last 60 days and related model, client.

## How can (was) this tested?

Tested with input json in Cursor and Studio version 1.2.9

## Checklist:

- [x] I have bumped the version number for the Action Package / Agent
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - README.md file
- [x] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
