### PR TITLE
Allow setting event as free/busy for create and update events

### DIFF
--- a/actions/google-calendar/CHANGELOG.md
+++ b/actions/google-calendar/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+
+## [1.2.0] - 2025-08-13
+
+### Added
+
+- Support for setting event free/busy via `transparency` ("opaque" for busy, "transparent" for free). Works with both create and update event actions.
+
 ## [1.1.3] - 2025-08-07
 
 ### Changed

--- a/actions/google-calendar/README.md
+++ b/actions/google-calendar/README.md
@@ -16,7 +16,7 @@ Give me all the events from this friday.
 ```
 
 > Here are the events from friday:
-> 
+>
 > 1. Home
 >    * Start: June 19, 2024
 >    * End: June 20, 2024
@@ -33,7 +33,7 @@ Give me all the events from this friday.
 >    * Description: Sync meeting for DevTools. Topics are raised in #dev-tools-team channel.
 >    * Attendees:
 >      * John, Doe, Albert, Robert
->      
+>
 > Let me know if you need more details or any other assistance!
 
 ```
@@ -57,3 +57,23 @@ Scopes in use:
 
     - https://www.googleapis.com/auth/calendar.events
     - https://www.googleapis.com/auth/calendar.readonly
+
+## Free/busy (transparency)
+
+You can control whether an event blocks time on your calendar via the `transparency` field.
+
+- `opaque`: counts as busy (default behavior)
+- `transparent`: does not block time (free)
+
+Example when creating:
+
+```json
+{
+  "summary": "Focus time",
+  "start": "2025-08-12T13:00:00+02:00",
+  "end": "2025-08-12T14:00:00+02:00",
+  "transparency": "transparent"
+}
+```
+
+You may also update an existing event's `transparency` using the update action.

--- a/actions/google-calendar/actions.py
+++ b/actions/google-calendar/actions.py
@@ -39,7 +39,7 @@ def create_event(
     """
     service = _build_service(google_credentials)
 
-    event_dict = event.model_dump(mode="json", exclude={"id"})
+    event_dict = event.model_dump(mode="json", exclude={"id"}, exclude_none=True)
 
     event_dict["start"] = {"dateTime": event_dict["start"]}
     event_dict["end"] = {"dateTime": event_dict["end"]}

--- a/actions/google-calendar/models.py
+++ b/actions/google-calendar/models.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Literal
 
 from pydantic import BaseModel, Field
 from pydantic.functional_validators import BeforeValidator
@@ -100,6 +100,15 @@ class Event(BaseModel):
     reminders: Annotated[
         Reminder | None, Field(description="Reminders settings for the event")
     ] = None
+    transparency: Annotated[
+        Literal["opaque", "transparent"] | None,
+        Field(
+            description=(
+                "Whether the event blocks time on the calendar. "
+                "'opaque' means busy (default), 'transparent' means free."
+            )
+        ),
+    ] = None
 
 
 class CreateEvent(Event):
@@ -132,6 +141,15 @@ class UpdateEvent(BaseModel):
     ] = None
     reminders: Annotated[
         Reminder | None, Field(description="Reminders settings for the event")
+    ] = None
+    transparency: Annotated[
+        Literal["opaque", "transparent"] | None,
+        Field(
+            description=(
+                "Whether the event blocks time on the calendar. "
+                "Use 'opaque' for busy or 'transparent' for free."
+            )
+        ),
     ] = None
 
 

--- a/actions/google-calendar/package.yaml
+++ b/actions/google-calendar/package.yaml
@@ -5,7 +5,7 @@ name: Google Calendar
 description: List calendars and search, create and update events in your Google Calendar.
 
 # Package version number, recommend using semver.org
-version: 1.1.3
+version: 1.2.0
 
 # The version of the `package.yaml` format.
 spec-version: v2
@@ -13,13 +13,13 @@ spec-version: v2
 dependencies:
   conda-forge:
     - python=3.11.11
-    - python-dotenv=1.1.0
+    - python-dotenv=1.1.1
     - uv=0.6.11
   pypi:
     - sema4ai-actions=1.4.1
     - pydantic=2.11.7
-    - google-api-python-client=2.157.0
-    - google-auth-oauthlib=1.2.1
+    - google-api-python-client=2.178.0
+    - google-auth-oauthlib=1.2.2
     - google-auth-httplib2=0.2.0
 
 external-endpoints:


### PR DESCRIPTION
## Description

Allow setting an event as busy or free when using the create or update event actions.

## How can (was) this tested?

Tested in the Sema4.ai Studio v1.4.2

## Screenshots (if needed)

## Checklist:

- [x] I have bumped the version number for the Action Package / Agent
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - README.md file
- [x] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
