### PR TITLE
Microsoft Mail to support chat files

### DIFF
--- a/actions/microsoft-mail/.gitignore
+++ b/actions/microsoft-mail/.gitignore
@@ -13,3 +13,4 @@ output/
 temp/
 venv/
 ./**/.env
+devdata/chat-files

--- a/actions/microsoft-mail/CHANGELOG.md
+++ b/actions/microsoft-mail/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.0] - 2025-09-04
+
+## BREAKING CHANGE
+
+- Attachment saving no longer supports local filesystem. Instead files are saved into Agent Chat Files.
+
+### Added
+
+- Added `get_email_by_subject` action
+
+### Changed
+
+- Modified `save_attachments` parameter in `get_email_by_id` action from string to boolean with default False
+- When `save_attachments=True`, attachments are now saved with Files API
+- Removed `make_dirs` parameter as it's no longer needed with the new attachment approach
+- Updated dependencies
+
 ## [1.4.2] - 2025-08-07
 
 ### Changed

--- a/actions/microsoft-mail/devdata/input_get_email_by_subject.json
+++ b/actions/microsoft-mail/devdata/input_get_email_by_subject.json
@@ -1,11 +1,13 @@
 {
     "inputs": [
         {
-            "inputName": "get email without attachments",
+            "inputName": "get email by subject - partial match",
             "inputValue": {
-                "email_id": "AAMkADljMzQ1YTc1LTRmYzItNDAzNC1hOGY4LWRkYjQyZmQ1NWYzYwBGAAAAAAD_YFfAbcBcSY3mIrVczQAlBwCocMixc6q8QqX43pcAKHryAAAAAAEMAACocMixc6q8QqX43pcAKHryAAUkAIMFAAA=",
+                "subject": "check this one",
+                "folder_to_search": "inbox",
                 "show_full_body": false,
                 "save_attachments": false,
+                "exact_match": false,
                 "vscode:request:oauth2": {
                     "token": {
                         "type": "OAuth2Secret",
@@ -19,11 +21,13 @@
             }
         },
         {
-            "inputName": "get email with attachments attached to chat",
+            "inputName": "get email by subject - exact match",
             "inputValue": {
-                "email_id": "",
+                "subject": "Weekly Team Meeting",
+                "folder_to_search": "inbox",
                 "show_full_body": false,
-                "save_attachments": true,
+                "save_attachments": false,
+                "exact_match": true,
                 "vscode:request:oauth2": {
                     "token": {
                         "type": "OAuth2Secret",
@@ -37,11 +41,33 @@
             }
         },
         {
-            "inputName": "get email with full body and attachments",
+            "inputName": "get email by subject with attachments",
             "inputValue": {
-                "email_id": "",
+                "subject": "check this one",
+                "folder_to_search": "inbox",
                 "show_full_body": true,
                 "save_attachments": true,
+                "exact_match": false,
+                "vscode:request:oauth2": {
+                    "token": {
+                        "type": "OAuth2Secret",
+                        "provider": "microsoft",
+                        "scopes": [
+                            "Mail.Read"
+                        ],
+                        "access_token": ""
+                    }
+                }
+            }
+        },
+        {
+            "inputName": "get email by subject from specific folder",
+            "inputValue": {
+                "subject": "project",
+                "folder_to_search": "Drafts",
+                "show_full_body": false,
+                "save_attachments": false,
+                "exact_match": false,
                 "vscode:request:oauth2": {
                     "token": {
                         "type": "OAuth2Secret",
@@ -56,12 +82,14 @@
         }
     ],
     "metadata": {
-        "actionName": "get_email_by_id",
+        "actionName": "get_email_by_subject",
         "actionRelativePath": "microsoft_mail/email_action.py",
         "schemaDescription": [
-            "email_id: string: The unique identifier of the email to retrieve.",
+            "subject: string: The subject line to search for.",
+            "folder_to_search: string: The folder to search for emails. Default is 'inbox'.",
             "show_full_body: boolean: Whether to show the full body content.",
-            "save_attachments: boolean: Whether to attach the email attachments to the chat using sema4ai.actions.chat."
+            "save_attachments: boolean: Whether to attach the email attachments to the chat using sema4ai.actions.chat.",
+            "exact_match: boolean: Whether to match the subject exactly (case-insensitive). Default is False (partial match)."
         ],
         "managedParamsSchemaDescription": {
             "token": {
@@ -75,6 +103,6 @@
         },
         "inputFileVersion": "v3",
         "kind": "action",
-        "actionSignature": "action/args: \"token: OAuth2Secret[Literal['microsoft'], list[Literal['Mail.Read']]], email_id: str, show_full_body: bool=False, save_attachments: bool=False\""
+        "actionSignature": "action/args: \"token: OAuth2Secret[Literal['microsoft'], list[Literal['Mail.Read']]], subject: str, folder_to_search: str='inbox', show_full_body: bool=False, save_attachments: bool=False, exact_match: bool=False\""
     }
 }

--- a/actions/microsoft-mail/package.yaml
+++ b/actions/microsoft-mail/package.yaml
@@ -5,7 +5,7 @@ name: Microsoft Mail
 description: Actions for Microsoft 365 Outlook emails.
 
 # Package version number, recommend using semver.org
-version: 1.4.2
+version: 2.0.0
 
 # The version of the `package.yaml` format.
 spec-version: v2
@@ -13,10 +13,10 @@ spec-version: v2
 dependencies:
   conda-forge:
     - python=3.11.11
-    - python-dotenv=1.1.0
+    - python-dotenv=1.1.1
     - uv=0.6.11
   pypi:
-    - sema4ai-actions=1.4.1
+    - sema4ai-actions=1.4.2
     - pydantic=2.11.7
 
 external-endpoints:


### PR DESCRIPTION
## Description

Microsoft Mail to support Agent Chat Files when saving attachments.

## How can (was) this tested?

In Cursor with the Sema4.ai SDK and in Sema4.ai Studio 1.4.6

## Screenshots (if needed)

## Checklist:

- [ ] I have bumped the version number for the Action Package / Agent
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - README.md file
- [ ] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
