### PR TITLE
Feature/handle categories microsoft mail

### DIFF
--- a/actions/microsoft-mail/CHANGELOG.md
+++ b/actions/microsoft-mail/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.1.0] - 2025-09-04
+
+### Added
+
+- Added `has_attachments` boolean parameter to `list_emails` action for filtering emails with attachments
+- Added comprehensive Microsoft Graph API OData query syntax examples in `list_emails` docstring
+- Added actions for adding/removing category to/from an email.
+
+### Changed
+
+- Enhanced folder-specific endpoint usage for inbox queries to improve reliability
+
 ## [2.0.0] - 2025-09-04
 
 ## BREAKING CHANGE

--- a/actions/microsoft-mail/devdata/input_add_category.json
+++ b/actions/microsoft-mail/devdata/input_add_category.json
@@ -1,0 +1,46 @@
+{
+    "inputs": [
+        {
+            "inputName": "input-1",
+            "inputValue": {
+                "email_id": "AAMkADljMzQ1YTc1LTRmYzItNDAzNC1hOGY4LWRkYjQyZmQ1NWYzYwBGAAAAAAD_YFfAbcBcSY3mIrVczQAlBwCocMixc6q8QqX43pcAKHryAAAAAAEMAACocMixc6q8QqX43pcAKHryAAUsRlWVAAA=",
+                "category": {
+                    "display_name": "Category Test6",
+                    "color": "preset12"
+                },
+                "vscode:request:oauth2": {
+                    "token": {
+                        "type": "OAuth2Secret",
+                        "provider": "microsoft",
+                        "scopes": [
+                            "Mail.ReadWrite"
+                        ],
+                        "access_token": "<access-token-will-be-requested-by-vscode>"
+                    }
+                }
+            }
+        }
+    ],
+    "metadata": {
+        "actionName": "add_category",
+        "actionRelativePath": "microsoft_mail/email_action.py",
+        "schemaDescription": [
+            "email_id: string: The unique identifier of the email to add the category to (provide a valid email ID).",
+            "category.display_name: string: Display name of the category (e.g., 'Processed by Agent')",
+            "category.color: string: Color of the category (e.g., 'Preset19', 'Preset0', etc.)"
+        ],
+        "managedParamsSchemaDescription": {
+            "token": {
+                "type": "OAuth2Secret",
+                "description": "The OAuth2 token for authentication.",
+                "provider": "microsoft",
+                "scopes": [
+                    "Mail.ReadWrite"
+                ]
+            }
+        },
+        "inputFileVersion": "v3",
+        "kind": "action",
+        "actionSignature": "action/args: \"token: OAuth2Secret[Literal['microsoft'], list[Literal['Mail.ReadWrite']]], email_id: str, category: Category\""
+    }
+}

--- a/actions/microsoft-mail/devdata/input_get_email_by_subject.json
+++ b/actions/microsoft-mail/devdata/input_get_email_by_subject.json
@@ -43,7 +43,7 @@
         {
             "inputName": "get email by subject with attachments",
             "inputValue": {
-                "subject": "check this one",
+                "subject": "Test Email with Attachment",
                 "folder_to_search": "inbox",
                 "show_full_body": true,
                 "save_attachments": true,

--- a/actions/microsoft-mail/devdata/input_list_emails.json
+++ b/actions/microsoft-mail/devdata/input_list_emails.json
@@ -19,6 +19,70 @@
                     }
                 }
             }
+        },
+        {
+            "inputName": "input-2",
+            "inputValue": {
+                "search_query": "hasAttachments eq true",
+                "folder_to_search": "inbox",
+                "properties_to_return": "subject,from,receivedDateTime",
+                "return_only_count": false,
+                "vscode:request:oauth2": {
+                    "token": {
+                        "type": "OAuth2Secret",
+                        "provider": "microsoft",
+                        "scopes": [
+                            "Mail.Read",
+                            "User.Read"
+                        ],
+                        "access_token": "<access-token-will-be-requested-by-vscode>"
+                    }
+                }
+            }
+        },
+        {
+            "inputName": "input-3",
+            "inputValue": {
+                "search_query": "*",
+                "folder_to_search": "inbox",
+                "properties_to_return": "id,subject,from,receivedDateTime,hasAttachments",
+                "max_emails_to_return": 10,
+                "return_only_count": false,
+                "has_attachments": true,
+                "vscode:request:oauth2": {
+                    "token": {
+                        "type": "OAuth2Secret",
+                        "provider": "microsoft",
+                        "scopes": [
+                            "Mail.Read",
+                            "User.Read"
+                        ],
+                        "access_token": "<access-token-will-be-requested-by-vscode>"
+                    }
+                }
+            }
+        },
+        {
+            "inputName": "input-4",
+            "inputValue": {
+                "search_query": "receivedDateTime gt 2024-09-26",
+                "folder_to_search": "inbox",
+                "properties_to_return": "id,subject,from,receivedDateTime,hasAttachments",
+                "max_emails_to_return": 20,
+                "return_only_count": false,
+                "has_attachments": true,
+                "vscode:request:oauth2": {
+                    "token": {
+                        "type": "OAuth2Secret",
+                        "provider": "microsoft",
+                        "scopes": [
+                            "Mail.Read",
+                            "User.Read"
+                        ],
+                        "access_token": "<access-token-will-be-requested-by-vscode>"
+                    }
+                }
+            }
         }
     ],
     "metadata": {
@@ -29,7 +93,8 @@
             "folder_to_search: string: The folder to search for emails. Default is 'inbox'.",
             "properties_to_return: string: The properties to return in the response. Default is all properties. Comma separated list of properties, like 'idsubject,body,toRecipients'.",
             "max_emails_to_return: integer: Maximum number of emails to return. Default is -1 (return all emails).",
-            "return_only_count: boolean: Limit response size, but still return the count matching the query."
+            "return_only_count: boolean: Limit response size, but still return the count matching the query.",
+            "has_attachments: boolean: Filter emails to only include those with attachments. Default is False."
         ],
         "managedParamsSchemaDescription": {
             "token": {
@@ -44,6 +109,6 @@
         },
         "inputFileVersion": "v3",
         "kind": "action",
-        "actionSignature": "action/args: \"token: OAuth2Secret[Literal['microsoft'], list[Literal['Mail.Read', 'User.Read']]], search_query: str, folder_to_search: str='inbox', properties_to_return: str='', max_emails_to_return: int=-1, return_only_count: bool=False\""
+        "actionSignature": "action/args: \"token: OAuth2Secret[Literal['microsoft'], list[Literal['Mail.Read', 'User.Read']]], search_query: str, folder_to_search: str='inbox', properties_to_return: str='', max_emails_to_return: int=-1, return_only_count: bool=False, has_attachments: bool=False\""
     }
 }

--- a/actions/microsoft-mail/devdata/input_list_emails.json
+++ b/actions/microsoft-mail/devdata/input_list_emails.json
@@ -46,7 +46,7 @@
                 "search_query": "*",
                 "folder_to_search": "inbox",
                 "properties_to_return": "id,subject,from,receivedDateTime,hasAttachments",
-                "max_emails_to_return": 10,
+                "max_emails_to_return": 100,
                 "return_only_count": false,
                 "has_attachments": true,
                 "vscode:request:oauth2": {
@@ -71,6 +71,68 @@
                 "max_emails_to_return": 20,
                 "return_only_count": false,
                 "has_attachments": true,
+                "vscode:request:oauth2": {
+                    "token": {
+                        "type": "OAuth2Secret",
+                        "provider": "microsoft",
+                        "scopes": [
+                            "Mail.Read",
+                            "User.Read"
+                        ],
+                        "access_token": "<access-token-will-be-requested-by-vscode>"
+                    }
+                }
+            }
+        },
+        {
+            "inputName": "input-5",
+            "inputValue": {
+                "search_query": "*",
+                "folder_to_search": "inbox",
+                "properties_to_return": "id,subject,from,receivedDateTime,hasAttachments",
+                "max_emails_to_return": 50,
+                "return_only_count": false,
+                "has_attachments": false,
+                "vscode:request:oauth2": {
+                    "token": {
+                        "type": "OAuth2Secret",
+                        "provider": "microsoft",
+                        "scopes": [
+                            "Mail.Read",
+                            "User.Read"
+                        ],
+                        "access_token": "<access-token-will-be-requested-by-vscode>"
+                    }
+                }
+            }
+        },
+        {
+            "inputName": "input-6",
+            "inputValue": {
+                "search_query": "*",
+                "folder_to_search": "",
+                "properties_to_return": "id,subject,from,receivedDateTime,hasAttachments",
+                "max_emails_to_return": 10,
+                "return_only_count": false,
+                "has_attachments": true,
+                "vscode:request:oauth2": {
+                    "token": {
+                        "type": "OAuth2Secret",
+                        "provider": "microsoft",
+                        "scopes": [
+                            "Mail.Read",
+                            "User.Read"
+                        ],
+                        "access_token": "<access-token-will-be-requested-by-vscode>"
+                    }
+                }
+            }
+        },
+        {
+            "inputName": "list 5 latest emails",
+            "inputValue": {
+                "search_query": "*",
+                "max_emails_to_return": 5,
                 "vscode:request:oauth2": {
                     "token": {
                         "type": "OAuth2Secret",

--- a/actions/microsoft-mail/devdata/input_list_master_categories.json
+++ b/actions/microsoft-mail/devdata/input_list_master_categories.json
@@ -1,0 +1,39 @@
+{
+    "inputs": [
+        {
+            "inputName": "input-1",
+            "inputValue": {
+                "vscode:request:oauth2": {
+                    "token": {
+                        "type": "OAuth2Secret",
+                        "provider": "microsoft",
+                        "scopes": [
+                            "Mail.ReadWrite"
+                        ],
+                        "access_token": "<access-token-will-be-requested-by-vscode>"
+                    }
+                }
+            }
+        }
+    ],
+    "metadata": {
+        "actionName": "list_master_categories",
+        "actionRelativePath": "microsoft_mail/email_action.py",
+        "schemaDescription": [
+            "No parameters required - lists all master categories with their colors"
+        ],
+        "managedParamsSchemaDescription": {
+            "token": {
+                "type": "OAuth2Secret",
+                "description": "The OAuth2 token for authentication.",
+                "provider": "microsoft",
+                "scopes": [
+                    "Mail.ReadWrite"
+                ]
+            }
+        },
+        "inputFileVersion": "v3",
+        "kind": "action",
+        "actionSignature": "action/args: \"token: OAuth2Secret[Literal['microsoft'], list[Literal['Mail.ReadWrite']]]\""
+    }
+}

--- a/actions/microsoft-mail/devdata/input_remove_category.json
+++ b/actions/microsoft-mail/devdata/input_remove_category.json
@@ -1,0 +1,42 @@
+{
+    "inputs": [
+        {
+            "inputName": "input-1",
+            "inputValue": {
+                "email_id": "",
+                "category_name": "Processed by Agent",
+                "vscode:request:oauth2": {
+                    "token": {
+                        "type": "OAuth2Secret",
+                        "provider": "microsoft",
+                        "scopes": [
+                            "Mail.ReadWrite"
+                        ],
+                        "access_token": "<access-token-will-be-requested-by-vscode>"
+                    }
+                }
+            }
+        }
+    ],
+    "metadata": {
+        "actionName": "remove_category",
+        "actionRelativePath": "microsoft_mail/email_action.py",
+        "schemaDescription": [
+            "email_id: string: The unique identifier of the email to remove the category from (provide a valid email ID).",
+            "category_name: string: The name of the category to remove."
+        ],
+        "managedParamsSchemaDescription": {
+            "token": {
+                "type": "OAuth2Secret",
+                "description": "The OAuth2 token for authentication.",
+                "provider": "microsoft",
+                "scopes": [
+                    "Mail.ReadWrite"
+                ]
+            }
+        },
+        "inputFileVersion": "v3",
+        "kind": "action",
+        "actionSignature": "action/args: \"token: OAuth2Secret[Literal['microsoft'], list[Literal['Mail.ReadWrite']]], email_id: str, category_name: str\""
+    }
+}

--- a/actions/microsoft-mail/microsoft_mail/models.py
+++ b/actions/microsoft-mail/microsoft_mail/models.py
@@ -71,3 +71,14 @@ class MessageFlag(BaseModel):
 
     class Config:
         use_enum_values = True
+
+
+class Category(BaseModel):
+    display_name: str = Field(description="Display name of the category")
+    color: Optional[str] = Field(default="Preset19", description="Color of the category (e.g., Preset19, Preset0, etc.)")
+
+
+class CategoryList(BaseModel):
+    categories: Annotated[
+        List[Category], Field(description="A list of categories")
+    ] = []

--- a/actions/microsoft-mail/microsoft_mail/support.py
+++ b/actions/microsoft-mail/microsoft_mail/support.py
@@ -209,3 +209,65 @@ def _find_folder(folders, folder_to_search):
             if result:
                 return result
     return None
+
+
+def _check_category_exists(token, category_name, headers):
+    """Check if a category exists in master categories."""
+    try:
+        response = send_request(
+            "get",
+            "/me/outlook/masterCategories",
+            "check category exists",
+            headers=headers,
+        )
+        if response and "value" in response:
+            categories = response["value"]
+            return any(cat["displayName"] == category_name for cat in categories)
+        return False
+    except Exception:
+        return False
+
+
+def _create_category(token, category_name, category_color, headers):
+    """Create a new category in master categories."""
+    payload = {
+        "displayName": category_name,
+        "color": category_color
+    }
+    try:
+        send_request(
+            "post",
+            "/me/outlook/masterCategories",
+            "create category",
+            headers=headers,
+            data=payload,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def _get_category_info(token, category_name, headers):
+    """Get information about a specific category from master categories."""
+    try:
+        response = send_request(
+            "get",
+            "/me/outlook/masterCategories",
+            "get category info",
+            headers=headers,
+        )
+        if response and "value" in response:
+            categories = response["value"]
+            for cat in categories:
+                if cat["displayName"] == category_name:
+                    return cat
+        return None
+    except Exception:
+        return None
+
+
+def _ensure_category_exists(token, category_name, headers, category_color="Preset19"):
+    """Ensure a category exists in master categories, create it if it doesn't.
+    Uses the provided color or defaults to Preset19."""
+    if not _check_category_exists(token, category_name, headers):
+        _create_category(token, category_name, category_color, headers)

--- a/actions/microsoft-mail/package.yaml
+++ b/actions/microsoft-mail/package.yaml
@@ -5,7 +5,7 @@ name: Microsoft Mail
 description: Actions for Microsoft 365 Outlook emails including category management (add/remove categories).
 
 # Package version number, recommend using semver.org
-version: 2.2.0
+version: 2.1.0
 
 # The version of the `package.yaml` format.
 spec-version: v2

--- a/actions/microsoft-mail/package.yaml
+++ b/actions/microsoft-mail/package.yaml
@@ -2,10 +2,10 @@
 name: Microsoft Mail
 
 # Required: A description of what's in the action package.
-description: Actions for Microsoft 365 Outlook emails.
+description: Actions for Microsoft 365 Outlook emails including category management (add/remove categories).
 
 # Package version number, recommend using semver.org
-version: 2.0.0
+version: 2.2.0
 
 # The version of the `package.yaml` format.
 spec-version: v2


### PR DESCRIPTION
## Description

This PR adds comprehensive email category management functionality to the Microsoft Mail action package, enabling users to add, remove, and list categories for Outlook emails. The implementation includes automatic category creation in master categories and preserves existing categories when adding new ones.

### Key Features Added:
- **Add Category Action**: Add categories to emails while preserving existing categories
- **Remove Category Action**: Remove specific categories from emails
- **List Master Categories Action**: Retrieve all available master categories with their colors
- **Enhanced List Emails Action**: Added `has_attachments` parameter for filtering emails with attachments
- **Comprehensive OData Query Documentation**: Added detailed Microsoft Graph API query syntax examples

### Technical Implementation:
- Added new `Category` and `CategoryList` models with proper validation
- Implemented helper functions for category management in `support.py`
- Enhanced `list_emails` action with attachment filtering and improved folder-specific endpoint usage
- Added comprehensive error handling and validation for category operations
- Updated package version from 2.0.0 to 2.1.0

### Dependencies:
- No new external dependencies required
- Uses existing Microsoft Graph API endpoints
- Requires `Mail.ReadWrite` OAuth2 scope for category management operations

## How can (was) this tested?

The functionality has been tested using the provided test data files in the `devdata/` directory:

### Test Cases:
- [x] **Add Category Test**: Test adding a new category to an email with custom color (Preset12)
- [x] **Remove Category Test**: Test removing a specific category from an email
- [x] **List Master Categories Test**: Test retrieving all available master categories
- [x] **List Emails with Attachments**: Test filtering emails by attachment presence
- [x] **Category Preservation**: Verify existing categories are preserved when adding new ones
- [x] **Error Handling**: Test handling of non-existent categories and invalid email IDs

### Test Configuration:
- [x] OAuth2 authentication with Microsoft Graph API
- [x] Valid email IDs for testing category operations
- [x] Test categories with different color presets
- [x] Inbox folder testing for attachment filtering

### Reproduction Instructions:
1. Use the test data files in `devdata/` directory
2. Ensure valid OAuth2 token with `Mail.ReadWrite` scope
3. Provide valid email IDs from your Outlook mailbox
4. Test each action individually using the provided input files

## Screenshots (if needed)

No screenshots needed as this is a backend API enhancement.

## Checklist:

- [x] I have bumped the version number for the Action Package / Agent (2.0.0 → 2.1.0)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation - README.md file
- [x] I have updated the CHANGELOG.md file in correspondence with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)