### PR TITLE
Add additional Serper endpoints

### DIFF
--- a/actions/serper/actions.py
+++ b/actions/serper/actions.py
@@ -66,7 +66,7 @@ class SearchResult(BaseModel):
 @action
 def search_google(q: str, num: int, api_key: Secret) -> Response[SearchResult]:
     """
-    Perform a search using the Serper API and return a structured summary.
+    Perform a search using the Serper API and return a structured summary. The number of results can be specified.
 
     Args:
         q: The search query.

--- a/actions/serper/actions.py
+++ b/actions/serper/actions.py
@@ -263,15 +263,9 @@ class ReviewSearchResult(BaseModel):
 @action
 def search_google(q: str, num: int, api_key: Secret) -> Response[SearchResult]:
     """
-    Perform a search using the Serper API and return a structured summary. The number of results can be specified.
-
-    Args:
-        q: The search query.
-        num: The number of results to return.
-        api_key: The API key for authentication.
-
-    Returns:
-        SearchResult: A structured summary of the search results.
+    Perform a comprehensive Google search using the Serper API. Returns organic results, knowledge graphs, related questions, and more.
+    
+    You can specify the number of results to return (num, default: 10, max: 100).
     """
     # Validate inputs
     _validate_query(q)
@@ -296,21 +290,9 @@ def search_news(
     page: int = 1
 ) -> Response[NewsSearchResult]:
     """
-    Search for news articles using the Serper API with publication dates and source information.
-
-    Args:
-        q: The news search query.
-        api_key: The API key for authentication.
-        gl: Country code.
-        location: Location filter.
-        hl: Language code.
-        tbs: Time-based filter for news recency.
-        autocorrect: Enable/disable autocorrect.
-        num: Number of results (default: 10).
-        page: Page number (default: 1).
-
-    Returns:
-        NewsSearchResult: A structured summary of the news search results.
+    Search for recent news articles with publication dates, sources, and images. Perfect for staying updated on current events.
+    
+    You can specify the number of articles (num, default: 10), page number (page, default: 1), country (gl), and time filter (tbs: "qdr:h" for hour, "qdr:d" for day, "qdr:w" for week, "qdr:m" for month).
     """
     # Validate inputs
     _validate_query(q)
@@ -337,20 +319,9 @@ def search_shopping(
     page: int = 1
 ) -> Response[ShoppingSearchResult]:
     """
-    Search for products using the Serper API with pricing, ratings, and vendor information.
-
-    Args:
-        q: The product search query.
-        api_key: The API key for authentication.
-        gl: Country code.
-        location: Location filter.
-        hl: Language code.
-        autocorrect: Enable/disable autocorrect.
-        num: Number of results (default: 10).
-        page: Page number (default: 1).
-
-    Returns:
-        ShoppingSearchResult: A structured summary of the shopping search results.
+    Search for products with prices, ratings, and vendor information. Perfect for price comparison and product research.
+    
+    You can specify the number of products (num, default: 10), page number (page, default: 1), and country for localized pricing (gl).
     """
     # Validate inputs
     _validate_query(q)
@@ -376,19 +347,9 @@ def search_scholar(
     page: int = 1
 ) -> Response[ScholarSearchResult]:
     """
-    Search for academic papers and scholarly articles using the Serper API with citation data.
-
-    Args:
-        q: The academic search query.
-        api_key: The API key for authentication.
-        gl: Country code.
-        location: Location filter.
-        hl: Language code.
-        autocorrect: Enable/disable autocorrect.
-        page: Page number (default: 1).
-
-    Returns:
-        ScholarSearchResult: A structured summary of the scholarly search results.
+    Search for academic papers and scholarly articles with citations, publication info, and PDF links. Perfect for research and literature reviews.
+    
+    You can specify the page number (page, default: 1) and country for regional academic sources (gl).
     """
     # Validate inputs
     _validate_query(q)
@@ -410,16 +371,9 @@ def search_patents(
     page: int = 1
 ) -> Response[PatentSearchResult]:
     """
-    Search for patents and patent documents using the Serper API.
-
-    Args:
-        q: The patent search query.
-        api_key: The API key for authentication.
-        num: Number of results (default: 10).
-        page: Page number (default: 1).
-
-    Returns:
-        PatentSearchResult: A structured summary of the patent search results.
+    Search for patents with detailed metadata including inventors, filing dates, and PDF documents. Perfect for IP research and prior art searches.
+    
+    You can specify the number of patents (num, default: 10) and page number (page, default: 1).
     """
     # Validate inputs
     _validate_query(q)
@@ -443,19 +397,9 @@ def search_maps(
     page: int = 1
 ) -> Response[MapSearchResult]:
     """
-    Enhanced geographic search using the Serper API with detailed place information and opening hours.
-
-    Args:
-        q: The location search query.
-        api_key: The API key for authentication.
-        ll: GPS coordinates in format '@latitude,longitude,zoom'.
-        placeid: Google Place ID.
-        cid: Customer/location ID.
-        hl: Language code.
-        page: Page number (default: 1).
-
-    Returns:
-        MapSearchResult: A structured summary of the map search results.
+    Enhanced geographic search with detailed place information, opening hours, and ratings. Perfect for finding local businesses and locations.
+    
+    You can specify GPS coordinates (ll: '@latitude,longitude,zoom'), Google Place ID (placeid), or business ID (cid). Page number defaults to 1.
     """
     # Validate inputs
     _validate_query(q)
@@ -484,21 +428,9 @@ def search_places(
     page: int = 1
 ) -> Response[PlaceSearchResult]:
     """
-    Search for local businesses and places using the Serper API with contact and rating information.
-
-    Args:
-        q: The place search query.
-        api_key: The API key for authentication.
-        gl: Country code.
-        location: Location filter.
-        hl: Language code.
-        tbs: Time-based filter.
-        autocorrect: Enable/disable autocorrect.
-        num: Number of results (default: 10).
-        page: Page number (default: 1).
-
-    Returns:
-        PlaceSearchResult: A structured summary of the place search results.
+    Search for local businesses and places with contact information, ratings, and categories. Perfect for finding services and establishments.
+    
+    You can specify the number of places (num, default: 10), page number (page, default: 1), country (gl), and location filter.
     """
     # Validate inputs
     _validate_query(q)
@@ -526,21 +458,9 @@ def search_reviews(
     hl: Optional[str] = None
 ) -> Response[ReviewSearchResult]:
     """
-    Search for reviews of specific businesses or places using the Serper API.
-
-    Args:
-        api_key: The API key for authentication.
-        fid: Feature/business ID.
-        cid: Customer/client ID.
-        placeid: Google Place ID.
-        sortBy: Sort method (e.g., 'Most relevant').
-        topicId: Topic identifier.
-        nextPageToken: Pagination token.
-        gl: Country code.
-        hl: Language code.
-
-    Returns:
-        ReviewSearchResult: A structured summary of the review search results.
+    Search for customer reviews of specific businesses or places with ratings, dates, and detailed feedback. Perfect for reputation analysis.
+    
+    Requires at least one ID: business ID (fid), customer ID (cid), or Google Place ID (placeid). You can sort by "Most relevant", "Newest", "Highest rating", or "Lowest rating".
     """
     # Validate inputs
     if not any([fid, cid, placeid]):

--- a/actions/serper/devdata/input_search_maps.json
+++ b/actions/serper/devdata/input_search_maps.json
@@ -1,0 +1,31 @@
+{
+    "inputs": [
+        {
+            "inputName": "Search for coffee shops in San Francisco",
+            "inputValue": {
+                "q": "coffee shops San Francisco",
+                "ll": "@37.7749,-122.4194,12",
+                "hl": "en",
+                "api_key": ""
+            }
+        }
+    ],
+    "metadata": {
+        "actionName": "search_maps",
+        "actionRelativePath": "actions.py",
+        "schemaDescription": [
+            "q: string: The location search query.",
+            "ll: string: GPS coordinates in format '@latitude,longitude,zoom'.",
+            "hl: string: Language code."
+        ],
+        "managedParamsSchemaDescription": {
+            "api_key": {
+                "type": "Secret",
+                "description": "The API key for authentication."
+            }
+        },
+        "inputFileVersion": "v3",
+        "kind": "action",
+        "actionSignature": "action/args: 'q: str, api_key: Secret, ll: Optional[str] = None, placeid: Optional[str] = None, cid: Optional[str] = None, hl: Optional[str] = None, page: int = 1'"
+    }
+}

--- a/actions/serper/devdata/input_search_news.json
+++ b/actions/serper/devdata/input_search_news.json
@@ -1,0 +1,38 @@
+{
+    "inputs": [
+        {
+            "inputName": "Search for AI news",
+            "inputValue": {
+                "q": "artificial intelligence news",
+                "num": 5,
+                "gl": "us",
+                "hl": "en",
+                "tbs": "qdr:d",
+                "api_key": ""
+            }
+        }
+    ],
+    "metadata": {
+        "actionName": "search_news",
+        "actionRelativePath": "actions.py",
+        "schemaDescription": [
+            "q: string: The news search query.",
+            "num: integer: Number of results (default: 10).",
+            "gl: string: Country code.",
+            "hl: string: Language code.",
+            "tbs: string: Time-based filter for news recency."
+        ],
+        "managedParamsSchemaDescription": {
+            "api_key": {
+                "type": "Secret",
+                "description": "The API key for authentication."
+            }
+        },
+        "inputFileVersion": "v3",
+        "kind": "action",
+        "actionSignature": "action/args: 'q: str, api_key: Secret, gl: Optional[str] = None, location: Optional[str] = None, hl: Optional[str] = None, tbs: Optional[str] = None, autocorrect: Optional[bool] = None, num: int = 10, page: int = 1'"
+    }
+}
+
+
+

--- a/actions/serper/devdata/input_search_patents.json
+++ b/actions/serper/devdata/input_search_patents.json
@@ -1,0 +1,32 @@
+{
+    "inputs": [
+        {
+            "inputName": "Search for AI patents",
+            "inputValue": {
+                "q": "artificial intelligence patent",
+                "num": 5,
+                "api_key": ""
+            }
+        }
+    ],
+    "metadata": {
+        "actionName": "search_patents",
+        "actionRelativePath": "actions.py",
+        "schemaDescription": [
+            "q: string: The patent search query.",
+            "num: integer: Number of results (default: 10)."
+        ],
+        "managedParamsSchemaDescription": {
+            "api_key": {
+                "type": "Secret",
+                "description": "The API key for authentication."
+            }
+        },
+        "inputFileVersion": "v3",
+        "kind": "action",
+        "actionSignature": "action/args: 'q: str, api_key: Secret, num: int = 10, page: int = 1'"
+    }
+}
+
+
+

--- a/actions/serper/devdata/input_search_places.json
+++ b/actions/serper/devdata/input_search_places.json
@@ -1,0 +1,38 @@
+{
+    "inputs": [
+        {
+            "inputName": "Search for restaurants in New York",
+            "inputValue": {
+                "q": "Italian restaurants",
+                "num": 5,
+                "gl": "us",
+                "location": "New York, NY",
+                "hl": "en",
+                "api_key": ""
+            }
+        }
+    ],
+    "metadata": {
+        "actionName": "search_places",
+        "actionRelativePath": "actions.py",
+        "schemaDescription": [
+            "q: string: The place search query.",
+            "num: integer: Number of results (default: 10).",
+            "gl: string: Country code.",
+            "location: string: Location filter.",
+            "hl: string: Language code."
+        ],
+        "managedParamsSchemaDescription": {
+            "api_key": {
+                "type": "Secret",
+                "description": "The API key for authentication."
+            }
+        },
+        "inputFileVersion": "v3",
+        "kind": "action",
+        "actionSignature": "action/args: 'q: str, api_key: Secret, gl: Optional[str] = None, location: Optional[str] = None, hl: Optional[str] = None, tbs: Optional[str] = None, autocorrect: Optional[bool] = None, num: int = 10, page: int = 1'"
+    }
+}
+
+
+

--- a/actions/serper/devdata/input_search_reviews.json
+++ b/actions/serper/devdata/input_search_reviews.json
@@ -1,0 +1,36 @@
+{
+    "inputs": [
+        {
+            "inputName": "Search for restaurant reviews",
+            "inputValue": {
+                "placeid": "ChIJN1t_tDeuEmsRUsoyG83frY4",
+                "sortBy": "Most relevant",
+                "gl": "us",
+                "hl": "en",
+                "api_key": ""
+            }
+        }
+    ],
+    "metadata": {
+        "actionName": "search_reviews",
+        "actionRelativePath": "actions.py",
+        "schemaDescription": [
+            "placeid: string: Google Place ID.",
+            "sortBy: string: Sort method (e.g., 'Most relevant').",
+            "gl: string: Country code.",
+            "hl: string: Language code."
+        ],
+        "managedParamsSchemaDescription": {
+            "api_key": {
+                "type": "Secret",
+                "description": "The API key for authentication."
+            }
+        },
+        "inputFileVersion": "v3",
+        "kind": "action",
+        "actionSignature": "action/args: 'api_key: Secret, fid: Optional[str] = None, cid: Optional[str] = None, placeid: Optional[str] = None, sortBy: Optional[str] = None, topicId: Optional[str] = None, nextPageToken: Optional[str] = None, gl: Optional[str] = None, hl: Optional[str] = None'"
+    }
+}
+
+
+

--- a/actions/serper/devdata/input_search_scholar.json
+++ b/actions/serper/devdata/input_search_scholar.json
@@ -1,0 +1,34 @@
+{
+    "inputs": [
+        {
+            "inputName": "Search for machine learning papers",
+            "inputValue": {
+                "q": "machine learning algorithms",
+                "gl": "us",
+                "hl": "en",
+                "api_key": ""
+            }
+        }
+    ],
+    "metadata": {
+        "actionName": "search_scholar",
+        "actionRelativePath": "actions.py",
+        "schemaDescription": [
+            "q: string: The academic search query.",
+            "gl: string: Country code.",
+            "hl: string: Language code."
+        ],
+        "managedParamsSchemaDescription": {
+            "api_key": {
+                "type": "Secret",
+                "description": "The API key for authentication."
+            }
+        },
+        "inputFileVersion": "v3",
+        "kind": "action",
+        "actionSignature": "action/args: 'q: str, api_key: Secret, gl: Optional[str] = None, location: Optional[str] = None, hl: Optional[str] = None, autocorrect: Optional[bool] = None, page: int = 1'"
+    }
+}
+
+
+

--- a/actions/serper/devdata/input_search_shopping.json
+++ b/actions/serper/devdata/input_search_shopping.json
@@ -1,0 +1,36 @@
+{
+    "inputs": [
+        {
+            "inputName": "Search for laptop deals",
+            "inputValue": {
+                "q": "gaming laptop",
+                "num": 5,
+                "gl": "us",
+                "hl": "en",
+                "api_key": ""
+            }
+        }
+    ],
+    "metadata": {
+        "actionName": "search_shopping",
+        "actionRelativePath": "actions.py",
+        "schemaDescription": [
+            "q: string: The product search query.",
+            "num: integer: Number of results (default: 10).",
+            "gl: string: Country code.",
+            "hl: string: Language code."
+        ],
+        "managedParamsSchemaDescription": {
+            "api_key": {
+                "type": "Secret",
+                "description": "The API key for authentication."
+            }
+        },
+        "inputFileVersion": "v3",
+        "kind": "action",
+        "actionSignature": "action/args: 'q: str, api_key: Secret, gl: Optional[str] = None, location: Optional[str] = None, hl: Optional[str] = None, autocorrect: Optional[bool] = None, num: int = 10, page: int = 1'"
+    }
+}
+
+
+


### PR DESCRIPTION
## Summary
Added 8 new search endpoints to complement the existing `search_google` action and refactored the structure to keep things simple.

## New Search Endpoints
- News search - articles with publication dates and sources
- Shopping search - products with prices and ratings  
- Scholar search - academic papers with citations
- Patent search - patents with filing dates and inventors
- Maps search - places with location details and hours
- Places search - local businesses with contact info
- Reviews search - customer reviews and ratings

## Testing
- Added action package to studio 1.5.0-rc1
- Made calls to each endpoint (video attached)

## Changes
- Added optional parameters for filtering and localization across all endpoints
- Updated docstrings to show key parameters and defaults for better tooltips
- Refactored with helper functions to reduce duplicate code
- Enhanced Pydantic data models to capture more fields from API responses

## Notes
Intentionally excluded image, video, and lens search endpoints.

Didn't spend a ton of time over-engineering this since we'll eventually switch to MCP like [serper-mcp-server](https://github.com/garylab/serper-mcp-server).