### PR TITLE
Add full agent .zips to S3

### DIFF
--- a/bin/publisher/agents_manifest.py
+++ b/bin/publisher/agents_manifest.py
@@ -7,7 +7,72 @@ from pathlib import Path
 
 from models import AgentsWhitelistEntry, AgentInfo
 from models import AgentActionPackage, AgentsManifest, AgentVersionInfo
-from utils import read_yaml_file
+from utils import read_yaml_file, calculate_file_hash
+
+
+def build_agent_package(
+    agent_folder: str, agent_name: str, agent_version: str, agent_cli_path: str
+) -> tuple[str, str] | None:
+    """
+    Build an agent package zip file using agent-cli package build command.
+    
+    Parameters:
+        agent_folder (str): The path to the agent folder.
+        agent_name (str): The name of the agent.
+        agent_version (str): The version of the agent.
+        agent_cli_path (str): The path to the agent cli executable.
+    
+    Returns:
+        tuple[str, str] | None: A tuple of (zip_file_path, zip_hash) if successful, None if failed.
+    """
+    # Create a zips directory in the project root for building packages
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    zips_dir = os.path.join(script_dir, "zips")
+    os.makedirs(zips_dir, exist_ok=True)
+    
+    kebab_case_agent_name = to_kebab_case(agent_name)
+    zip_filename = f"{kebab_case_agent_name}.zip"
+    zip_file_path = os.path.join(zips_dir, zip_filename)
+    
+    # Build the agent package using agent-cli
+    command = [
+        agent_cli_path,
+        "package",
+        "build",
+        "--input-dir", agent_folder,
+        "--name", zip_filename,
+        "--output-dir", zips_dir,
+        "--overwrite"
+    ]
+    
+    print(f"Building agent package: {' '.join(command)}")
+    
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            cwd=agent_folder
+        )
+        
+        if result.returncode != 0:
+            print(f"Agent package build failed for {agent_name} {agent_version}: {result.stderr}")
+            return None
+        
+        # Check if the zip file was created
+        if not os.path.exists(zip_file_path):
+            print(f"Agent package zip file not found after build: {zip_file_path}")
+            return None
+        
+        # Calculate the hash of the zip file
+        zip_hash = calculate_file_hash(zip_file_path)
+        
+        print(f"Successfully built agent package for {agent_name} {agent_version}")
+        return (zip_file_path, zip_hash)
+        
+    except Exception as e:
+        print(f"Error building agent package for {agent_name} {agent_version}: {str(e)}")
+        return None
 
 
 def generate_agents_manifest(
@@ -60,6 +125,14 @@ def generate_agents_manifest(
         with open(os.path.join(agent_folder, "runbook.md")) as file:
             runbook_content = file.read()
 
+        # Build the agent package
+        package_result = build_agent_package(agent_folder, agent_name, agent_version, agent_cli_path)
+        if not package_result:
+            print(f"Skipping agent {agent_name} {agent_version} due to package build failure")
+            continue
+        
+        zip_file_path, zip_hash = package_result
+
         actions = get_actions_info(agent_spec_data["action-packages"])
         base_url = "https://cdn.sema4.ai/gallery/agents/"
 
@@ -75,6 +148,8 @@ def generate_agents_manifest(
             "knowledge": agent_spec_data["knowledge"],
             "metadata": agent_spec_data["metadata"],
             "action_packages": actions,
+            "agent_package_zip_url": f"{base_url}{kebab_case_agent_name}/{agent_version}/{kebab_case_agent_name}.zip",
+            "agent_package_zip_hash": zip_hash,
         }
 
         # Copy the interesting files to be uploaded in S3
@@ -89,6 +164,11 @@ def generate_agents_manifest(
                 Path(agent_folder) / "agent-spec.yaml", dest / "agent-spec.yaml"
             )
             shutil.copyfile(Path(agent_folder) / "CHANGELOG.md", dest / "CHANGELOG.md")
+        
+        # Always copy the zip file if it doesn't exist (zip files are version-specific)
+        zip_dest_path = dest / f"{kebab_case_agent_name}.zip"
+        if not os.path.exists(zip_dest_path):
+            shutil.copyfile(zip_file_path, zip_dest_path)
 
         agent_info: AgentInfo = {
             "name": agent_name,
@@ -185,6 +265,15 @@ def is_agent_published(published_manifest: AgentsManifest, agent_name: str, vers
 
     if version not in versions:
         return False
+
+    # Check if the agent version has the required zip file fields
+    agent_versions = published_manifest.get("agents", {}).get(agent_name, {}).get("versions", [])
+    for agent_version in agent_versions:
+        if agent_version.get("version") == version:
+            # Check if both zip URL and hash are present
+            if "agent_package_zip_url" not in agent_version or "agent_package_zip_hash" not in agent_version:
+                return False
+            break
 
     return True
 

--- a/bin/publisher/models.py
+++ b/bin/publisher/models.py
@@ -59,6 +59,8 @@ class AgentVersionInfo(TypedDict):
     version: str
     description: str
     agent_spec: str
+    agent_package_zip_url: str
+    agent_package_zip_hash: str
     changelog: str
     runbook: str
     architecture: str

--- a/bin/publisher/tools.py
+++ b/bin/publisher/tools.py
@@ -9,7 +9,7 @@ from utils import get_working_dir
 
 as_version = "2.14.3"
 rcc_version = "v19.0.2"
-agent_cli_version = "v2.1.2"
+agent_cli_version = "v2.2.0"
 
 
 def get_agent_cli_path() -> str:

--- a/bin/publisher/utils.py
+++ b/bin/publisher/utils.py
@@ -27,6 +27,11 @@ def sha256(filepath: str, hash_type: str = "sha256") -> str:
     return hash_obj.hexdigest()
 
 
+def calculate_file_hash(filepath: str) -> str:
+    """Calculate the SHA-256 hash of a file and return the hex digest."""
+    return sha256(filepath, "sha256")
+
+
 def log_error(error_message: str, sub_folder_path: str = None) -> None:
     with open("log.txt", "a") as log_file:
         message = f"Error in folder {sub_folder_path}: " if sub_folder_path else ""


### PR DESCRIPTION
## Description

- New fields to manifest.json:
  - `agent_package_zip_url`
  - `agent_package_zip_hash`
- Build the agent zips on update
- Consider agent published only when the zip is found

## How can (was) this tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.

Please also list any relevant details for your test configuration:

- [ ] Test A
- [ ] Test B

## Screenshots (if needed)

## Checklist:

- [ ] I have bumped the version number for the Action Package / Agent
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - README.md file
- [ ] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
