### PR TITLE
Agent Connector: Use WorkItemPayload model for create_work_item_for_agent

### DIFF
--- a/actions/agent-connector/CHANGELOG.md
+++ b/actions/agent-connector/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-### [4.2.0] - 2026-01-27
+### [4.2.1] - 2026-02-10
+
+### Changed
+
+- Updated `create_work_item_for_agent()` payload parameter from `dict` to `WorkItemPayload` Pydantic model with `extra="allow"` for flexible payload structure
+- Updated sema4ai-actions to `1.6.6`
+
+### [4.1.1] - 2026-01-27
 
 ### Added
 

--- a/actions/agent-connector/actions.py
+++ b/actions/agent-connector/actions.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from sema4ai.actions import (
     ActionError,
     Response,
@@ -114,6 +114,12 @@ class WorkItemResponse(BaseModel):
     work_item: dict
     agent_name: str
     agent_id: str
+
+
+class WorkItemPayload(BaseModel):
+    """Payload for creating a work item. Accepts any additional properties."""
+
+    model_config = ConfigDict(extra="allow")
 
 @action
 def ask_agent(
@@ -312,7 +318,7 @@ def send_message(
 @action
 def create_work_item_for_agent(
     agent_name: str,
-    payload: dict,
+    payload: WorkItemPayload,
     sema4_api_key: Secret,
     attachments: list[str] | None = None,
     work_item_api_url: str | None = None,
@@ -321,7 +327,7 @@ def create_work_item_for_agent(
 
     Args:
         agent_name: The name of the agent to run the Work Item
-        payload: JSON payload to send as the Work Item payload
+        payload: JSON payload to send as the Work Item payload (any properties allowed)
         sema4_api_key: The API key for the Sema4 API if running in cloud. Use LOCAL if in Studio or SDK!
         attachments: Optional list of file paths to attach to the Work Item
         work_item_api_url: Optional Work Item API URL override
@@ -337,7 +343,7 @@ def create_work_item_for_agent(
     agent = agent_result.agent
     work_item = client.create_work_item(
         agent_id=agent.id,
-        payload=payload,
+        payload=payload.model_dump(exclude_none=True),
         attachments=attachments,
         work_item_api_url=work_item_api_url,
     )

--- a/actions/agent-connector/package.yaml
+++ b/actions/agent-connector/package.yaml
@@ -5,7 +5,7 @@ name: Agent Connector
 description: Actions to connect agents with each other
 
 # Package version number, recommend using semver.org
-version: 4.1.1
+version: 4.2.1
 
 # The version of the `package.yaml` format.
 spec-version: v2
@@ -18,7 +18,7 @@ dependencies:
     - python=3.11.11
     - uv=0.6.11
   pypi:
-    - sema4ai-actions=1.4.2
+    - sema4ai-actions=1.6.6
 
 packaging:
   # By default, all files and folders in this directory are packaged when uploaded.


### PR DESCRIPTION
## Summary

The `payload` parameter type `dict` is causing problems in tool discovery and recognition between the action server and the agent server.

Below is an example of agent reasoning, which eventually can cause unwanted disruption (manual input from the user) in the agent flow, which is meant to run automatically after initial input

> Adapting to tool limitations
> 
> I've noticed that the API signature for functions.create_work_item_for_agent only requires agent_name, an attachments list, and the work_item_api_url. There's a mismatch between the tool's definition and what the Runbook Step 8 suggests. The tool doesn’t allow for payload fields, which limits what I can send.
> 
> Although the Runbook provides an extended signature, I need to follow the tool reference closely. I can still create a work item using the agent name and attachments, and I'll assume the context may be added automatically. After success, I’ll categorize the emails based on classification.

- Changed `create_work_item_for_agent()` payload parameter from `dict` to `WorkItemPayload` Pydantic model
- `WorkItemPayload` uses `ConfigDict(extra="allow")` for flexible payload structure
- Updated sema4ai-actions to `1.6.6`
- Bumped version to 4.2.1

## Test plan

- [x] Test `create_work_item_for_agent()` with various payload structures
- [x] Verify extra properties are passed through correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)