### PR TITLE
Updated template agents to new architecture

### DIFF
--- a/agents/action-writer-agent/CHANGELOG.md
+++ b/agents/action-writer-agent/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - 2026-02-19
+- Update to the latest version of the agent architecture
+
 ## [1.0.2] - 2025-06-18
 
 - Update to the latest version of the action packages

--- a/agents/action-writer-agent/agent-spec.yaml
+++ b/agents/action-writer-agent/agent-spec.yaml
@@ -18,7 +18,7 @@ agent-package:
       provider: OpenAI
       name: gpt-4o
     version: 1.0.2
-    architecture: agent
+    architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md
     action-packages:

--- a/agents/action-writer-agent/agent-spec.yaml
+++ b/agents/action-writer-agent/agent-spec.yaml
@@ -17,7 +17,7 @@ agent-package:
     model:
       provider: OpenAI
       name: gpt-4o
-    version: 1.0.2
+    version: 1.1.0
     architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md

--- a/agents/agent-writer-agent/CHANGELOG.md
+++ b/agents/agent-writer-agent/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - 2026-02-19
+- Update to the latest version of the agent architecture
+
 ## [1.0.2] - 2025-06-18
 
 - Update to the latest version of the action packages
-
 
 ## [1.0.1] - 2025-04-04
 

--- a/agents/agent-writer-agent/agent-spec.yaml
+++ b/agents/agent-writer-agent/agent-spec.yaml
@@ -18,7 +18,7 @@ agent-package:
     model:
       provider: OpenAI
       name: gpt-4o
-    version: 1.0.2
+    version: 1.1.0
     architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md

--- a/agents/agent-writer-agent/agent-spec.yaml
+++ b/agents/agent-writer-agent/agent-spec.yaml
@@ -19,7 +19,7 @@ agent-package:
       provider: OpenAI
       name: gpt-4o
     version: 1.0.2
-    architecture: agent
+    architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md
     action-packages:

--- a/agents/cortex-analyst-example/CHANGELOG.md
+++ b/agents/cortex-analyst-example/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.0] - 2026-02-19
+- Update to the latest version of the agent architecture
+
 ## [0.1.5] - 2025-11-11
 
 - Update to the latest version of the action packages
-
 
 ## [0.1.3] - 2025-06-18
 

--- a/agents/cortex-analyst-example/agent-spec.yaml
+++ b/agents/cortex-analyst-example/agent-spec.yaml
@@ -7,7 +7,7 @@ agent-package:
     model:
       provider: Snowflake Cortex AI
       name: claude-3-5-sonnet
-    version: 0.1.5
+    version: 0.2.0
     architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md

--- a/agents/cortex-analyst-example/agent-spec.yaml
+++ b/agents/cortex-analyst-example/agent-spec.yaml
@@ -8,7 +8,7 @@ agent-package:
       provider: Snowflake Cortex AI
       name: claude-3-5-sonnet
     version: 0.1.5
-    architecture: agent
+    architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md
     conversation-guide: conversation-guide.yaml

--- a/agents/cortex-search-example/CHANGELOG.md
+++ b/agents/cortex-search-example/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.0] - 2026-02-19
+- Update to the latest version of the agent architecture
+  
 ## [0.1.6] - 2025-11-11
 
 - Update to the latest version of the action packages

--- a/agents/cortex-search-example/agent-spec.yaml
+++ b/agents/cortex-search-example/agent-spec.yaml
@@ -7,7 +7,7 @@ agent-package:
     model:
       provider: Snowflake Cortex AI
       name: claude-3-5-sonnet
-    version: 0.1.9
+    version: 0.2.0
     architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md

--- a/agents/cortex-search-example/agent-spec.yaml
+++ b/agents/cortex-search-example/agent-spec.yaml
@@ -8,7 +8,7 @@ agent-package:
       provider: Snowflake Cortex AI
       name: claude-3-5-sonnet
     version: 0.1.9
-    architecture: agent
+    architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md
     conversation-guide: conversation-guide.yaml

--- a/agents/document-explorer/CHANGELOG.md
+++ b/agents/document-explorer/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - 2026-02-19
+- Update to the latest version of the agent architecture
+  
 ## [1.0.4] - 2025-11-12
 
 - Update to the latest `document-insights` action package

--- a/agents/document-explorer/agent-spec.yaml
+++ b/agents/document-explorer/agent-spec.yaml
@@ -7,7 +7,7 @@ agent-package:
       provider: OpenAI
       name: gpt-4o
     version: 1.0.4
-    architecture: agent
+    architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md
     conversation-guide: conversation-guide.yaml

--- a/agents/document-explorer/agent-spec.yaml
+++ b/agents/document-explorer/agent-spec.yaml
@@ -6,7 +6,7 @@ agent-package:
     model:
       provider: OpenAI
       name: gpt-4o
-    version: 1.0.4
+    version: 1.1.0
     architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md

--- a/agents/document-parser/CHANGELOG.md
+++ b/agents/document-parser/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.0] - 2026-02-19
+- Update to the latest version of the agent architecture
+  
 ## [0.1.1] - 2025-12-16
 
 - Update action package to the latest version
-
 
 ## [0.1.0] - 2025-11-11
 

--- a/agents/document-parser/agent-spec.yaml
+++ b/agents/document-parser/agent-spec.yaml
@@ -7,7 +7,7 @@ agent-package:
     model:
       provider: OpenAI
       name: gpt-5-minimal
-    version: 0.1.1
+    version: 0.2.0
     architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md

--- a/agents/document-parser/agent-spec.yaml
+++ b/agents/document-parser/agent-spec.yaml
@@ -8,7 +8,7 @@ agent-package:
       provider: OpenAI
       name: gpt-5-minimal
     version: 0.1.1
-    architecture: agent
+    architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md
     action-packages:

--- a/agents/oil-and-gas-analyst/CHANGELOG.md
+++ b/agents/oil-and-gas-analyst/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.1.0] - 2026-02-19
+- Update to the latest version of the agent architecture
+
 ## [0.0.1] - 2025-09-10
 
 - First version published, changelog tracking starts.

--- a/agents/oil-and-gas-analyst/agent-spec.yaml
+++ b/agents/oil-and-gas-analyst/agent-spec.yaml
@@ -6,7 +6,7 @@ agent-package:
     model:
       provider: Amazon
       name: anthropic.claude-3-5-sonnet-20240620-v1:0
-    version: 0.0.1
+    version: 0.1.0
     architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md

--- a/agents/oil-and-gas-analyst/agent-spec.yaml
+++ b/agents/oil-and-gas-analyst/agent-spec.yaml
@@ -7,7 +7,7 @@ agent-package:
       provider: Amazon
       name: anthropic.claude-3-5-sonnet-20240620-v1:0
     version: 0.0.1
-    architecture: agent
+    architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md
     conversation-guide: conversation-guide.yaml

--- a/agents/sales-contact-finder/CHANGELOG.md
+++ b/agents/sales-contact-finder/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - 2026-02-19
+- Update to the latest version of the agent architecture
+
 ## [1.0.2] - 2025-06-18
 
 - Update to the latest version of the action packages

--- a/agents/sales-contact-finder/agent-spec.yaml
+++ b/agents/sales-contact-finder/agent-spec.yaml
@@ -20,7 +20,7 @@ agent-package:
     model:
       provider: Snowflake Cortex AI
       name: claude-3-5-sonnet
-    version: 1.0.2
+    version: 1.1.0
     architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md

--- a/agents/sales-contact-finder/agent-spec.yaml
+++ b/agents/sales-contact-finder/agent-spec.yaml
@@ -21,7 +21,7 @@ agent-package:
       provider: Snowflake Cortex AI
       name: claude-3-5-sonnet
     version: 1.0.2
-    architecture: agent
+    architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md
     action-packages:

--- a/agents/similar-company-finder/CHANGELOG.md
+++ b/agents/similar-company-finder/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - 2026-02-19
+- Update to the latest version of the agent architecture
+
 ## [1.0.2] - 2025-06-18
 
 - Update to the latest version of the action packages

--- a/agents/similar-company-finder/agent-spec.yaml
+++ b/agents/similar-company-finder/agent-spec.yaml
@@ -20,7 +20,7 @@ agent-package:
       provider: Snowflake Cortex AI
       name: claude-3-5-sonnet
     version: 1.0.2
-    architecture: agent
+    architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md
     action-packages:

--- a/agents/similar-company-finder/agent-spec.yaml
+++ b/agents/similar-company-finder/agent-spec.yaml
@@ -19,7 +19,7 @@ agent-package:
     model:
       provider: Snowflake Cortex AI
       name: claude-3-5-sonnet
-    version: 1.0.2
+    version: 1.1.0
     architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md

--- a/agents/wayback-machine-agent/CHANGELOG.md
+++ b/agents/wayback-machine-agent/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.0] - 2026-02-19
+- Update to the latest version of the agent architecture
+
 ## [1.0.2] - 2025-06-18
 
 - Update to the latest version of the action packages

--- a/agents/wayback-machine-agent/agent-spec.yaml
+++ b/agents/wayback-machine-agent/agent-spec.yaml
@@ -17,7 +17,7 @@ agent-package:
     model:
       provider: OpenAI
       name: gpt-4o
-    version: 1.0.1
+    version: 1.1.0
     architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md

--- a/agents/wayback-machine-agent/agent-spec.yaml
+++ b/agents/wayback-machine-agent/agent-spec.yaml
@@ -18,7 +18,7 @@ agent-package:
       provider: OpenAI
       name: gpt-4o
     version: 1.0.1
-    architecture: agent
+    architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md
     action-packages:

--- a/demos/payment-remittance-reconciliation-agent/agent-spec.yaml
+++ b/demos/payment-remittance-reconciliation-agent/agent-spec.yaml
@@ -15,7 +15,7 @@ agent-package:
       provider: OpenAI
       name: gpt-4o
     version: 0.1.1
-    architecture: agent
+    architecture: agent_platform.architectures.experimental_1
     reasoning: disabled
     runbook: runbook.md
     action-packages:


### PR DESCRIPTION
## Description

Template agents were all using the old agent architecture. This PR updates them:

```architecture: agent```

to

```architecture: agent_platform.architectures.experimental_1```

And in addition each agent version is incremented with one minor.

## How can (was) this tested?

This has NOT been tested by using all the template agents, only the yaml update has been done.

## Screenshots (if needed)

## Checklist:

- [X] I have bumped the version number for the Action Package / Agent
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - README.md file
- [x] I have updated the CHANGELOG.md file in correspondence with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] OAuth2: I have made sure that action has necessary scopes (works in whitelisted mode)
